### PR TITLE
[DM-27867] Set the release channel on GKE environments

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -25,6 +25,7 @@ secondary_ranges = {
 }
 
 # GKE
+release_channel = "RAPID"
 master_ipv4_cidr_block = "172.16.0.0/28"
 # node_pool_1_name = "core-pool"
 # node_pool_1_machine_type = "e2-standard-4" # 4 vCPU 16GB RAM

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -39,6 +39,7 @@ module "gke" {
   subnetwork             = local.subnetwork
   master_ipv4_cidr_block = var.master_ipv4_cidr_block
   node_pools             = var.node_pools
+  release_channel        = var.release_channel
 
   # Labels
   cluster_resource_labels = {

--- a/environment/deployments/science-platform/gke/variables.tf
+++ b/environment/deployments/science-platform/gke/variables.tf
@@ -24,6 +24,10 @@ variable "master_ipv4_cidr_block" {
   default = "172.16.0.0/28"
 }
 
+variable "release_channel" {
+  default = "REGULAR"
+}
+
 variable "zones" {
   description = "The zones to host the cluster in (optional if regional cluster / required if zonal)"
   type        = list(string)

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -127,8 +127,8 @@ variable "remove_default_node_pool" {
 
 variable "release_channel" {
   type        = string
-  description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`."
-  default     = "STABLE"
+  description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."
+  default     = "REGULAR"
 }
 
 variable "enable_resource_consumption_export" {


### PR DESCRIPTION
Make the default release channel REGULAR, and set the release
channel to the dev environment to RAPID so that we can use it for
early testing of Kubernetes compatibility.