### PR TITLE
DM-28288: Add non-GKE groups for the Processing folder

### DIFF
--- a/environment/foundation/1-org-b/iam.tf
+++ b/environment/foundation/1-org-b/iam.tf
@@ -56,6 +56,18 @@ resource "google_folder_iam_member" "gcp_processing_gke_developer_iam_permission
   role     = each.value
   member   = "group:${module.constants.values.groups.gcp_processing_gke_developer}"
 }
+resource "google_folder_iam_member" "gcp_processing_nongke_admins_iam_permissions" {
+  for_each = toset(var.gcp_processing_nongke_admins_iam_permissions)
+  folder   = data.google_active_folder.processing_sub_folder.name
+  role     = each.value
+  member   = "group:${module.constants.values.groups.gcp_processing_nongke_admins}"
+}
+resource "google_folder_iam_member" "gcp_processing_nongke_developer_iam_permissions" {
+  for_each = toset(var.gcp_processing_nongke_developer_iam_permissions)
+  folder   = data.google_active_folder.processing_sub_folder.name
+  role     = each.value
+  member   = "group:${module.constants.values.groups.gcp_processing_nongke_developer}"
+}
 
 resource "google_folder_iam_member" "gcp_processing_administrator_iam_permissions" {
   for_each = toset(var.gcp_processing_administrators_iam_permissions)

--- a/environment/foundation/1-org-b/variables.tf
+++ b/environment/foundation/1-org-b/variables.tf
@@ -87,6 +87,7 @@ variable "gcp_processing_nongke_admins_iam_permissions" {
     "roles/logging.admin",
     "roles/monitoring.admin",
     "roles/storage.admin",
+    "roles/cloudbuild.builds.editor",
     "roles/file.editor"
   ]
 }

--- a/environment/foundation/1-org-b/variables.tf
+++ b/environment/foundation/1-org-b/variables.tf
@@ -75,6 +75,22 @@ variable "gcp_square_gke_cluster_admins_iam_permissions" {
   ]
 }
 
+variable "gcp_processing_nongke_admins_iam_permissions" {
+  description = "List of permissions granted to the group."
+  type        = list(string)
+  default = [
+    "roles/iam.serviceAccountUser",
+    "roles/compute.instanceAdmin.v1",
+    "roles/compute.admin",
+    "roles/compute.networkAdmin",
+    "roles/cloudsql.admin",
+    "roles/logging.admin",
+    "roles/monitoring.admin",
+    "roles/storage.admin",
+    "roles/file.editor"
+  ]
+}
+
 // CLUSTER DEVELOPERS
 variable "gcp_qserv_gke_developer_iam_permissions" {
   description = "List of permissions granted to the group."
@@ -125,6 +141,19 @@ variable "gcp_square_gke_developer_iam_permissions" {
     "roles/logging.viewer",
     "roles/monitoring.editor",
     "roles/storage.objectViewer",
+  ]
+}
+
+variable "gcp_processing_nongke_developer_iam_permissions" {
+  description = "List of permissions granted to the group."
+  type        = list(string)
+  default = [
+    "roles/iam.serviceAccountUser",
+    "roles/compute.instanceAdmin.v1",
+    "roles/cloudsql.client",
+    "roles/logging.viewer",
+    "roles/monitoring.viewer",
+    "roles/storage.objectViewer"
   ]
 }
 

--- a/environment/foundation/constants/constants.tf
+++ b/environment/foundation/constants/constants.tf
@@ -34,6 +34,9 @@ locals {
       gcp_processing_gke_developer       = "gcp-processing-gke-developer@lsst.cloud"
       gcp_science_platform_gke_developer = "gcp-science-platform-gke-developer@lsst.cloud"
       gcp_qserv_gke_developer            = "gcp-qserv-gke-developer@lsst.cloud"
+
+      gcp_processing_nongke_admins       = "gcp-processing-nongke-admins@lsst.cloud"
+      gcp_processing_nongke_developer    = "gcp-processing-nongke-developer@lsst.cloud"
     }
 
     // Shared VPC


### PR DESCRIPTION
For ad-hoc projects not using GKE, it seems quite a different set of permissions are needed.  So I'm starting this PR to see if this is the right approach to add new groups. Some users currently in the `gcp_processing_gke_cluster_admins` group probably should be moved to these new groups. Just using the PR to start the conversation.  If there are better ways, welcome to close this PR and start a new one.  We can assume all non-GKE projects are inside the `Processing` folder. 