### PR TITLE
Scale dask pool back down and make SSD default fileshare

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -27,25 +27,17 @@ secondary_ranges = {
 # GKE
 release_channel = "RAPID"
 master_ipv4_cidr_block = "172.16.0.0/28"
-# node_pool_1_name = "core-pool"
-# node_pool_1_machine_type = "e2-standard-4" # 4 vCPU 16GB RAM
-# node_pool_1_min_count = 1
-# node_pool_1_max_count = 15
-# node_pool_1_disk_size_gb = 100
-# node_pool_1_initial_node_count = 5
 
 node_pools = [
   {
     name               = "core-pool"
-    machine_type       = "e2-standard-4"
+    machine_type       = "n2-standard-4"
     node_locations     = "us-central1-b"
-    min_count          = 5
-    max_count          = 5
     local_ssd_count    = 0
     auto_repair        = true
     auto_upgrade       = true
     preemptible        = false
-    initial_node_count = 5
+    node_count         = 5
     image_type         = "cos_containerd"
     enable_secure_boot = true
     disk_size_gb       = "200"
@@ -55,13 +47,11 @@ node_pools = [
     name               = "dask-pool"
     machine_type       = "n2-standard-4"
     node_locations     = "us-central1-b"
-    min_count          = 0
-    max_count          = 0
+    node_count         = 0
     local_ssd_count    = 0
     auto_repair        = true
     auto_upgrade       = true
     preemptible        = false
-    initial_node_count = 0
     image_type         = "cos_containerd"
     enable_secure_boot = true
     disk_size_gb       = "200"
@@ -70,11 +60,6 @@ node_pools = [
 ]
 
 node_pools_labels = {
-  all = {
-      environment      = var.environment
-      project          = local.project_id
-      application_name = var.application_name
-  },
   core-pool = {
     infrastructure = "ok"
     jupyterlab = "ok"

--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -55,13 +55,13 @@ node_pools = [
     name               = "dask-pool"
     machine_type       = "n2-standard-4"
     node_locations     = "us-central1-b"
-    min_count          = 15
-    max_count          = 15
+    min_count          = 0
+    max_count          = 0
     local_ssd_count    = 0
     auto_repair        = true
     auto_upgrade       = true
     preemptible        = false
-    initial_node_count = 15
+    initial_node_count = 0
     image_type         = "cos_containerd"
     enable_secure_boot = true
     disk_size_gb       = "200"
@@ -70,11 +70,16 @@ node_pools = [
 ]
 
 node_pools_labels = {
+  all = {
+      environment      = var.environment
+      project          = local.project_id
+      application_name = var.application_name
+  },
   core-pool = {
-    dask= ""
+    infrastructure = "ok"
+    jupyterlab = "ok"
   },
   dask-pool = {
-    jupyterlab = ""
-    infrastructure = ""
+    dask = "ok"
   }
 }

--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -35,7 +35,8 @@ secondary_ranges = {
 # node_pool_1_initial_node_count = 5
 
 # Filestore
-fileshare_capacity = 2000
+fileshare_capacity = 2600
+fileshare_capacity = "BASIC_SSD"
 fs2_fileshare_capacity = 2600
 fs2_tier = "BASIC_SSD"
 

--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -27,12 +27,6 @@ secondary_ranges = {
 
 # GKE
 # master_ipv4_cidr_block = "172.16.0.0/28"
-# node_pool_1_name = "core-pool"
-# node_pool_1_machine_type = "e2-standard-4" # 4 vCPU 16GB RAM
-# node_pool_1_min_count = 1
-# node_pool_1_max_count = 15
-# node_pool_1_disk_size_gb = 100
-# node_pool_1_initial_node_count = 5
 
 # Filestore
 fileshare_capacity = 2600

--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -36,7 +36,7 @@ secondary_ranges = {
 
 # Filestore
 fileshare_capacity = 2600
-fileshare_capacity = "BASIC_SSD"
+fileshare_tier = "BASIC_SSD"
 fs2_fileshare_capacity = 2600
 fs2_tier = "BASIC_SSD"
 

--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -33,7 +33,7 @@ node_pools = [
   {
     name               = "core-pool"
     machine_type       = "n1-standard-4"
-    node_locations     = "us-central1-b,us-central1-c"
+    node_locations     = "us-central1-b"
     local_ssd_count    = 0
     auto_repair        = true
     auto_upgrade       = true

--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -66,10 +66,9 @@ node_pools_labels = {
   core-pool = {
     infrastructure = "ok",
     jupyterlab = "ok"
-   }
   },
-    dask-pool = {
-      dask = "ok"
+  dask-pool = {
+    dask = "ok"
   }
 }
 

--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -43,9 +43,36 @@ node_pools = [
     disk_size_gb       = "200"
     disk_type          = "pd-ssd"
     autoscaling        = "false"
-    node_count         = 4
+    node_count         = 5
   },
+  {
+    name               = "dask-pool"
+    machine_type       = "n1-standard-4"
+    node_locations     = "us-central1-b,us-central1-c"
+    local_ssd_count    = 0
+    auto_repair        = true
+    auto_upgrade       = true
+    preemptible        = false
+    image_type         = "cos_containerd"
+    enable_secure_boot = true
+    disk_size_gb       = "200"
+    disk_type          = "pd-ssd"
+    autoscaling        = "false"
+    node_count         = 0
+  }
 ]
+
+node_pools_labels = {
+  core-pool = {
+    infrastructure = "ok",
+    jupyterlab = "ok"
+   }
+  },
+    dask-pool = {
+      dask = "ok"
+  }
+}
+
 
 # TF State
 bucket = "lsst-terraform-state"

--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -48,7 +48,7 @@ node_pools = [
   {
     name               = "dask-pool"
     machine_type       = "n1-standard-4"
-    node_locations     = "us-central1-b,us-central1-c"
+    node_locations     = "us-central1-b"
     local_ssd_count    = 0
     auto_repair        = true
     auto_upgrade       = true

--- a/environment/deployments/science-platform/env/integration.tfvars
+++ b/environment/deployments/science-platform/env/integration.tfvars
@@ -27,46 +27,23 @@ secondary_ranges = {
 
 # GKE
 master_ipv4_cidr_block = "172.17.0.0/28"
-# node_pool_1_name = "core-pool"
-# node_pool_1_machine_type = "e2-standard-4" # 4 vCPU 16GB RAM
-# node_pool_1_min_count = 1
-# node_pool_1_max_count = 15
-# node_pool_1_disk_size_gb = 100
-# node_pool_1_initial_node_count = 5
 
 node_pools = [
   {
     name               = "core-pool"
-    machine_type       = "g1-small"
+    machine_type       = "n1-standard-4"
     node_locations     = "us-central1-b"
-    min_count          = 1
-    max_count          = 15
     local_ssd_count    = 0
     auto_repair        = true
     auto_upgrade       = true
     preemptible        = false
-    initial_node_count = 5
+    node_count         = 5
     image_type         = "cos_containerd"
     enable_secure_boot = true
-    disk_size_gb       = "100"
-    disk_type          = "pd-standard"
-  },
-  {
-    name               = "jhub-pool"
-    machine_type       = "g1-small"
-    node_locations     = "us-central1-b"
-    min_count          = 1
-    max_count          = 5
-    local_ssd_count    = 0
-    auto_repair        = true
-    auto_upgrade       = true
-    preemptible        = false
-    initial_node_count = 1
-    image_type         = "cos_containerd"
-    enable_secure_boot = true
-    disk_size_gb       = "100"
-    disk_type          = "pd-standard"
-  }]
+    disk_size_gb       = "200"
+    disk_type          = "pd-ssd"
+  }
+]
 
 # Filestore
 fileshare_capacity = 2600

--- a/environment/deployments/science-platform/env/integration.tfvars
+++ b/environment/deployments/science-platform/env/integration.tfvars
@@ -69,7 +69,7 @@ node_pools = [
   }]
 
 # Filestore
-fileshare_capacity = 2000
+fileshare_capacity = 2600
 
 # NAT
 nats = [{ name = "cloud-nat" }]

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -55,9 +55,6 @@ module "gke" {
       environment      = var.environment
       project          = local.project_id
       application_name = var.application_name
-      infrastructure   = "ok"
-      jupyterlab       = "ok"
-      dask             = "ok"
     }
   }
 }

--- a/environment/deployments/science-platform/variables.tf
+++ b/environment/deployments/science-platform/variables.tf
@@ -242,13 +242,13 @@ variable "fileshare_name" {
 variable "fileshare_capacity" {
   description = "File share capacity in GiB. This must be at least 1024 GiB for the standard tier, or 2560 GiB for the premium tier."
   type        = number
-  default     = 2000
+  default     = 2600
 }
 
 variable "tier" {
   description = "The service tier of the instance. Possible values are TIER_UNSPECIFIED, STANDARD, PREMIUM, BASIC_HDD, BASIC_SSD, and HIGH_SCALE_SSD."
   type        = string
-  default     = "STANDARD"
+  default     = "BASIC_SSD"
 }
 
 variable "modes" {
@@ -275,11 +275,13 @@ variable "fs2_fileshare_name" {
 variable "fs2_fileshare_capacity" {
   description = "File share capacity in GiB. This must be at least 1024 GiB for the standard tier, or 2560 GiB for the premium tier."
   type        = number
+  default     = 2600  
 }
 
 variable "fs2_tier" {
   description = "The service tier of the instance. Possible values are TIER_UNSPECIFIED, STANDARD, PREMIUM, BASIC_HDD, BASIC_SSD, and HIGH_SCALE_SSD."
   type        = string
+  default     = "BASIC_SSD"
 }
 
 variable "fs2_modes" {

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -61,7 +61,7 @@ variable "labels" {
 
 variable "machine_type" {
   description = "Machine type to create, e.g. n1-standard-1"
-  default     = "n1-standard-1"
+  default     = "n2-standard-4"
 }
 
 variable "can_ip_forward" {

--- a/modules/filestore/variables.tf
+++ b/modules/filestore/variables.tf
@@ -32,7 +32,7 @@ variable "zone" {
 variable "tier" {
   description = "The service tier of the instance. Possible values are TIER_UNSPECIFIED, STANDARD, PREMIUM, BASIC_HDD, BASIC_SSD, and HIGH_SCALE_SSD."
   type        = string
-  default     = "STANDARD"
+  default     = "BASIC_SSD"
 }
 
 variable "fileshare_name" {
@@ -44,7 +44,7 @@ variable "fileshare_name" {
 variable "fileshare_capacity" {
   description = "File share capacity in GiB. This must be at least 1024 GiB for the standard tier, or 2560 GiB for the premium tier."
   type        = number
-  default     = 2660
+  default     = 2600
 }
 
 variable "network" {

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -172,19 +172,17 @@ variable "node_pools" {
   default = [
     {
       name               = "core-pool"
-      machine_type       = "g1-small"
+      machine_type       = "n2-standard-4"
       node_locations     = "us-central1-b"
-      min_count          = 1
-      max_count          = 15
+      node_count         = 5
       local_ssd_count    = 0
       auto_repair        = true
       auto_upgrade       = true
       preemptible        = false
-      initial_node_count = 5
       image_type         = "cos_containerd"
       enable_secure_boot = true
-      disk_size_gb       = "100"
-      disk_type          = "pd-standard"
+      disk_size_gb       = "200"
+      disk_type          = "pd-ssd"
     },
   ]
 }


### PR DESCRIPTION
The old style node labels did not work--I ended up getting all labels in all pools.  So now I am also explicitly overriding "all" and we will see if that works.  I am shrinking the dask node pool down to zero size, but leaving the pool because I am sure we will want to scale it back up in future.