### PR TITLE
pinned provider to 3.51

### DIFF
--- a/environment/deployments/science-platform/backend.tf
+++ b/environment/deployments/science-platform/backend.tf
@@ -6,7 +6,7 @@ terraform {
   backend "gcs" {
   }
   required_providers {
-    google      = "~> 3.1"
-    google-beta = "~> 3.1"
+    google      = "~> 3.51.0"
+    google-beta = "~> 3.51.0"
   }
 }

--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -58,3 +58,4 @@ custom_rules = {
 
 # NAT
 nats = [{ name = "cloud-nat" }]
+


### PR DESCRIPTION
Pinning the google provider to a previous version. The current release of 3.54 breaks if the project has a budget assigned.