### PR TITLE
DM-28881: Increase default timeout for postgres creation or updates

### DIFF
--- a/environment/deployments/butler-repo/env/dev.tfvars
+++ b/environment/deployments/butler-repo/env/dev.tfvars
@@ -64,3 +64,4 @@ nat_name      = "cloud-nat"
   domain       = "lsst.cloud"
   owners       = ["hchiang-admin@lsst.cloud"]
   members      = ["hchiang@lsst.cloud"]
+

--- a/modules/cloudsql/postgres-private/main.tf
+++ b/modules/cloudsql/postgres-private/main.tf
@@ -22,6 +22,8 @@ module "cloudsql-db" {
   maintenance_window_hour         = var.maintenance_window_hour
   maintenance_window_update_track = var.maintenance_window_update_track
   pricing_plan                    = var.pricing_plan
+  create_timeout                  = var.create_timeout
+  update_timeout                  = var.update_timeout
 
   user_labels         = var.user_labels
   user_name           = var.user_name

--- a/modules/cloudsql/postgres-private/variables.tf
+++ b/modules/cloudsql/postgres-private/variables.tf
@@ -218,3 +218,15 @@ variable "description" {
   description = "Descriptions of the created service accounts (defaults to no description)"
   default     = "Service Account created by Terraform"
 }
+
+variable "create_timeout" {
+  description = "The optional timout that is applied to limit long database creates."
+  type        = string
+  default     = "20m"
+}
+
+variable "update_timeout" {
+  description = "The optional timout that is applied to limit long database updates."
+  type        = string
+  default     = "20m"
+}


### PR DESCRIPTION
It seems[ the upstream default](https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/modules/postgresql/variables.tf#L240) is 10m 