### PR TITLE
[DM-28891] Fix data-int IP range for validation webhooks

### DIFF
--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -36,6 +36,10 @@ fileshare_capacity = 3000
 #fileshare_tier = "BASIC_SSD"
 
 # FIREWALL
+#
+# This allows the Kubernetes master to talk to validation controllers
+# running inside the GKE cluster.  The IP range must match
+# master_ipv4_cidr_block in the GKE configuration.
 custom_rules = {
   cert-manager-terraform = {
     description          = "cert manager rule created by terraform"

--- a/environment/deployments/science-platform/env/integration.tfvars
+++ b/environment/deployments/science-platform/env/integration.tfvars
@@ -32,12 +32,16 @@ secondary_ranges = {
 #fileshare_capacity = 2600
 
 # FIREWALL
+#
+# This allows the Kubernetes master to talk to validation controllers
+# running inside the GKE cluster.  The IP range must match
+# master_ipv4_cidr_block in the GKE configuration.
 custom_rules = {
   cert-manager-terraform = {
     description          = "cert manager rule created by terraform"
     direction            = "INGRESS"
     action               = "allow"
-    ranges               = ["172.16.0.0/28"]
+    ranges               = ["172.18.0.0/28"]
     sources              = []
     targets              = ["gke-science-platform-int"]
     use_service_accounts = false

--- a/environment/deployments/science-platform/env/production.tfvars
+++ b/environment/deployments/science-platform/env/production.tfvars
@@ -31,6 +31,10 @@ fileshare_capacity = 8000
 
 
 # FIREWALL
+#
+# This allows the Kubernetes master to talk to validation controllers
+# running inside the GKE cluster.  The IP range must match
+# master_ipv4_cidr_block in the GKE configuration.
 custom_rules = {
   cert-manager-terraform = {
     description          = "cert manager rule created by terraform"


### PR DESCRIPTION
The firewall rule has to allow connections from the Kubernetes
master to the pods in the cluster so that it can query validation
webhooks.  The IP range in the rule for integration was copied from
dev, instead of matching the master IP range for integration (which
is not the same).