### PR TITLE
DM-29015: Use high-mem db type for panda

### DIFF
--- a/environment/deployments/panda/env/dev-cloudsql.tfvars
+++ b/environment/deployments/panda/env/dev-cloudsql.tfvars
@@ -1,7 +1,7 @@
 project_id     = "panda-dev-1a74"
 network        = "panda-dev-vpc"
 db_name        = "butler-registry-dev"
-tier           = "db-n1-standard-8"
+tier           = "db-custom-4-26624"
 database_flags = [
   {name = "temp_file_limit", value = 214748362},
   {name = "max_connections", value = 3000}


### PR DESCRIPTION
The last merge didn't create the postgres yet as the tier string was incorrect. 