### PR TITLE
[DM-28900] Add OAuth to Science Platform administrators

### DIFF
--- a/environment/foundation/1-org-b/1-org-b.tfvars
+++ b/environment/foundation/1-org-b/1-org-b.tfvars
@@ -98,7 +98,8 @@ gcp_science_platform_gke_cluster_admins_iam_permissions = [
   "roles/file.editor",
   "roles/compute.networkAdmin",
   "roles/compute.securityAdmin",
-  "roles/artifactregistry.admin"
+  "roles/artifactregistry.admin",
+  "roles/oauthconfig.editor"
 ]
 gcp_science_platform_gke_developer_iam_permissions = [
   "roles/container.clusterViewer",


### PR DESCRIPTION
Grant the roles/oauthconfig.editor role to Science Platform
administrators so that I can experiment with Google OAuth
authentication for Argo CD.