### PR TITLE
DM-29185: Add compute.instanceAdmin.v1 role to panda-admin group

### DIFF
--- a/environment/deployments/panda/env/dev.tfvars
+++ b/environment/deployments/panda/env/dev.tfvars
@@ -81,4 +81,3 @@ custom_rules = {
 # NAT
 address_count = 1
 nat_name      = "cloud-nat"
-

--- a/environment/deployments/panda/variables.tf
+++ b/environment/deployments/panda/variables.tf
@@ -78,7 +78,7 @@ variable "project_iam_permissions" {
     "roles/storage.admin",
     "roles/container.clusterAdmin",
     "roles/container.admin",
-    "roles/compute.instanceAdmin",
+    "roles/compute.instanceAdmin.v1",
     "roles/logging.admin",
     "roles/file.editor",
     "roles/compute.networkAdmin",


### PR DESCRIPTION
Based on [this](https://cloud.google.com/compute/docs/access/iam#connectinginstanceadmin ) roles/compute.instanceAdmin.v1 should provide enough permissions. 