### PR TITLE
[DM-29805] Enable GCE persistent disk CSI driver on data-dev

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -3,8 +3,9 @@ environment             = "dev"
 application_name        = "science-platform"
 
 # GKE
-release_channel = "RAPID"
+release_channel        = "RAPID"
 master_ipv4_cidr_block = "172.16.0.0/28"
+gce_pd_csi_driver      = true
 
 node_pools = [
   {

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -40,6 +40,7 @@ module "gke" {
   master_ipv4_cidr_block = var.master_ipv4_cidr_block
   node_pools             = var.node_pools
   release_channel        = var.release_channel
+  gce_pd_csi_driver      = var.gce_pd_csi_driver
 
   # Labels
   cluster_resource_labels = {

--- a/environment/deployments/science-platform/gke/variables.tf
+++ b/environment/deployments/science-platform/gke/variables.tf
@@ -34,6 +34,12 @@ variable "zones" {
   default     = ["us-central1-a"]
 }
 
+variable "gce_pd_csi_driver" {
+  description = "(Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver."
+  type        = bool
+  default     = false
+}
+
 variable "maintenance_start_time" {
   description = "Time window specified for daily maintenance operations in RFC3339 format"
   type        = string


### PR DESCRIPTION
We need this to be able to do persistent volume snapshots.  Will
change the default to true and enable it on the other science
platform clusters in a follow-up diff once this is tested and
working.