### PR TITLE
[DM-29085] Enable the GCE PD CSI driver on int and prod

### DIFF
--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -4,6 +4,7 @@ application_name        = "science-platform"
 
 # GKE
 master_ipv4_cidr_block = "172.18.0.0/28"
+gce_pd_csi_driver      = true
 
 node_pools = [
   {

--- a/environment/deployments/science-platform/env/production-gke.tfvars
+++ b/environment/deployments/science-platform/env/production-gke.tfvars
@@ -4,6 +4,7 @@ application_name        = "science-platform"
 
 # GKE
 master_ipv4_cidr_block = "172.30.0.0/28"
+gce_pd_csi_driver      = true
 
 node_pools = [
   {


### PR DESCRIPTION
We want to use the GCE Physical Disk CSI driver for Redis storage
for Gafaelfawr because it supports snapshots.  Enable it on int and
prod, matching the earlier change to enable it on dev.