### PR TITLE
Grant role/owner for gcp_square_administratotrs

### DIFF
--- a/environment/foundation/1-org-b/1-org-b.tfvars
+++ b/environment/foundation/1-org-b/1-org-b.tfvars
@@ -117,7 +117,7 @@ square_display_name          = "SQuaRE"
 gcp_square_administrators_iam_permissions = [
   "roles/resourcemanager.projectCreator",
   "roles/container.admin",
-  "roles/editor",
+  "roles/owner",
   "roles/artifactregistry.admin"
 ]
 gcp_square_gke_cluster_admins_iam_permissions = [


### PR DESCRIPTION
- Can manage roles and permissions for a project and all resources within the project.