### PR TITLE
[DM-28120] Use postgres-sql for RSP database instance

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -56,3 +56,4 @@ node_pools_labels = {
 db_maintenance_window_day          = 1
 db_maintenance_window_hour         = 22
 db_maintenance_window_update_track = "canary"
+

--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -53,6 +53,7 @@ node_pools_labels = {
 db_maintenance_window_day  = 2
 db_maintenance_window_hour = 22
 
+
 # TF State declared during pipeline
 # bucket = "lsst-terraform-state"
 # prefix = "qserv/int/gke"

--- a/environment/deployments/science-platform/env/production-gke.tfvars
+++ b/environment/deployments/science-platform/env/production-gke.tfvars
@@ -55,6 +55,7 @@ node_pools_labels = {
 db_maintenance_window_day  = 4
 db_maintenance_window_hour = 22
 
+
 # TF State declared during pipeline
 # bucket = "lsst-terraform-state"
 # prefix = "qserv/stable/gke"

--- a/modules/cloudsql/postgres-sql/main.tf
+++ b/modules/cloudsql/postgres-sql/main.tf
@@ -13,10 +13,15 @@ module "cloudsql-db" {
   disk_type                       = var.disk_type
   backup_configuration            = var.backup_configuration
   disk_autoresize                 = var.disk_autoresize
+  enable_default_db               = var.enable_default_db
+  enable_default_user             = var.enable_default_user
   maintenance_window_day          = var.maintenance_window_day
   maintenance_window_hour         = var.maintenance_window_hour
   maintenance_window_update_track = var.maintenance_window_update_track
   pricing_plan                    = var.pricing_plan
+
+  additional_databases = var.additional_databases
+  additional_users     = var.additional_users
 
   user_labels         = var.user_labels
   user_name           = var.user_name
@@ -25,8 +30,8 @@ module "cloudsql-db" {
   database_flags      = var.database_flags
 
   ip_configuration = {
-    ipv4_enabled        = true
-    private_network     = null
+    ipv4_enabled        = var.ipv4_enabled
+    private_network     = var.private_network
     require_ssl         = true
     authorized_networks = var.authorized_networks
   }

--- a/modules/cloudsql/postgres-sql/variables.tf
+++ b/modules/cloudsql/postgres-sql/variables.tf
@@ -75,6 +75,18 @@ variable "backup_configuration" {
   }
 }
 
+variable "enable_default_db" {
+  description = "Enable or disable the creation of the default database"
+  type        = bool
+  default     = true
+}
+
+variable "enable_default_user" {
+  description = "Enable or disable the creation of the default user"
+  type        = bool
+  default     = true
+}
+
 variable "maintenance_window_day" {
   description = "The day of week (1-7) for the master instance maintenance."
   type        = number
@@ -136,4 +148,35 @@ variable "random_instance_name" {
   type        = bool
   description = "Sets random suffix at the end of the Cloud SQL resource name"
   default     = true
+}
+
+variable "additional_databases" {
+  description = "A list of databases to be created in your cluster"
+  type = list(object({
+    name      = string
+    charset   = string
+    collation = string
+  }))
+  default = []
+}
+
+variable "additional_users" {
+  description = "A list of users to be created in your cluster"
+  type = list(object({
+    name     = string
+    password = string
+  }))
+  default = []
+}
+
+variable "ipv4_enabled" {
+  description = "Whether this Cloud SQL instance should be assigned a public IPV4 address"
+  type        = bool
+  default     = true
+}
+
+variable "private_network" {
+  description = "The VPC network from which the Cloud SQL instance is accessible for private IP. For example, projects/myProject/global/networks/default. Specifying a network enables private IP. Either `ipv4_enabled` must be enabled or a `private_network` must be configured. This setting can be updated, but it cannot be removed after it is set."
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
postgres-private attempts to set up a private networking resource
that is already managed by the separate CloudSQL deployment, and
therefore conflicts.  Enhance postgres-sql to take the same new
parameters we're using and use it instead, and directly create the
service account (since this conceptually isn't part of the database
anyway).