### PR TITLE
[DM-29925] Enable science-platform database backups on dev

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -47,6 +47,13 @@ module "db_science_platform" {
   ipv4_enabled                    = false
   private_network                 = data.google_compute_network.network.self_link
 
+  backup_configuration = {
+    enabled                        = var.backups_enabled
+    start_time                     = "09:00"
+    location                       = "us-central1"
+    point_in_time_recovery_enabled = false
+  }
+
   additional_databases = [
     {
       name      = "gafaelfawr"

--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -74,3 +74,9 @@ variable "db_maintenance_window_update_track" {
   description = "The update track of maintenance window for the master instance maintenance. Can be either `canary` or `stable`."
   default     = "stable"
 }
+
+variable "backups_enabled" {
+  type        = bool
+  description = "True if backup configuration is enabled"
+  default     = false
+}

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -14,3 +14,4 @@ butler_database_flags = [
 db_maintenance_window_day          = 1
 db_maintenance_window_hour         = 22
 db_maintenance_window_update_track = "canary"
+backups_enabled                    = true


### PR DESCRIPTION
Test backup configuration in preparation for enabling it on int
and prod.