### PR TITLE
[DM-29976] Apply gafaelfawr IAM config to int and prod

### DIFF
--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -15,3 +15,4 @@ butler_database_flags = [
 db_maintenance_window_day  = 2
 db_maintenance_window_hour = 22
 backups_enabled            = true
+

--- a/environment/deployments/science-platform/env/production-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/production-cloudsql.tfvars
@@ -16,3 +16,4 @@ butler_database_flags = [
 db_maintenance_window_day  = 4
 db_maintenance_window_hour = 22
 backups_enabled            = true
+


### PR DESCRIPTION
This seemed to work properly on dev, so apply the same Terraform
configuration for Google IAM bindings for the gafaelfawr service
account to int and prod.