### PR TITLE
removed reference to Google Group module

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -57,12 +57,6 @@ custom_rules = {
 address_count = 1
 nat_name      = "cloud-nat"
 
-# Google Group
-id           = "gcp-data-curation-administrators@lsst.cloud"
-display_name = "GCP Data Curation Administrators"
-description  = "GCP Data Curation Administrators"
-domain       = "lsst.cloud"
-
 project_iam_permissions = ["roles/storage.admin", "roles/storagetransfer.admin"]
 
 # Butler GCS Access Service Account

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -110,15 +110,6 @@ module "storage_bucket_2" {
   }
 }
 
-module "data_curation_admin_group" {
-  source = "../../../modules/google_groups"
-
-  id           = var.id
-  display_name = var.display_name
-  description  = var.description
-  domain       = var.domain
-}
-
 #---------------------------------------------------------------
 // Data Curation Prod
 #---------------------------------------------------------------

--- a/environment/deployments/data-curation/variables.tf
+++ b/environment/deployments/data-curation/variables.tf
@@ -198,46 +198,6 @@ variable "log_config_filter" {
   type        = string
   default     = "ERRORS_ONLY"
 }
-// Google Groups
-
-variable "id" {
-  description = "ID of the group. For Google-managed entities, the ID must be the email address the group"
-}
-
-variable "display_name" {
-  description = "Display name of the group"
-  default     = ""
-}
-
-variable "description" {
-  description = "Description of the group"
-  default     = ""
-}
-
-variable "domain" {
-  description = "Domain of the organization to create the group in. One of domain or customer_id must be specified"
-  default     = ""
-}
-
-variable "customer_id" {
-  description = "Customer ID of the organization to create the group in. One of domain or customer_id must be specified"
-  default     = ""
-}
-
-variable "owners" {
-  description = "Owners of the group. Each entry is the ID of an entity. For Google-managed entities, the ID must be the email address of an existing group, user or service account"
-  default     = []
-}
-
-variable "managers" {
-  description = "Managers of the group. Each entry is the ID of an entity. For Google-managed entities, the ID must be the email address of an existing group, user or service account"
-  default     = []
-}
-
-variable "members" {
-  description = "Members of the group. Each entry is the ID of an entity. For Google-managed entities, the ID must be the email address of an existing group, user or service account"
-  default     = []
-}
 
 // Data Curation Prod
 variable "data_curation_prod_names" {


### PR DESCRIPTION
Initial pipeline failed on the google group. We wanted the group to stay, so I removed it from tfstate and now removing any reference to it in the tf manifests.