### PR TITLE
[DM-30880] Bump shared Science Platform database size

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -46,6 +46,7 @@ module "db_science_platform" {
   random_instance_name            = true
   ipv4_enabled                    = false
   private_network                 = data.google_compute_network.network.self_link
+  tier                            = var.database_tier
 
   backup_configuration = {
     enabled                        = var.backups_enabled
@@ -70,6 +71,10 @@ module "db_science_platform" {
   ]
 
   database_flags = [
+    {
+      name  = "max_connections"
+      value = 100
+    },
     {
       name  = "password_encryption"
       value = "scram-sha-256"

--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -51,6 +51,12 @@ variable "butler_require_ssl" {
   default     = true
 }
 
+variable "database_tier" {
+  description = "The tier for general database"
+  type        = string
+  default     = "db-g1-small"
+}
+
 variable "database_version" {
   description = "The database version to use for the general database"
   type        = string

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -15,3 +15,6 @@ db_maintenance_window_day          = 1
 db_maintenance_window_hour         = 22
 db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
+
+# Increase this number to force Terraform to update the dev environment.
+# Serial: 1


### PR DESCRIPTION
We need to support more than 25 simultaneous connections to the
Gafaelfawr database to support load.  This is only possible with
a somewhat larger database instance.