### PR TITLE
[DM-32180] Set maintenance window for data-dev GKE

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -6,6 +6,9 @@ application_name        = "science-platform"
 release_channel        = "RAPID"
 master_ipv4_cidr_block = "172.16.0.0/28"
 gce_pd_csi_driver      = true
+maintenance_start_time = "2021-08-18T00:00:00Z"
+maintenance_end_time   = "2021-08-18T12:00:00Z"
+maintenance_recurrence = "FREQ=WEEKLY;BYDAY=WE"
 
 node_pools = [
   {

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -42,6 +42,9 @@ module "gke" {
   release_channel        = var.release_channel
   gce_pd_csi_driver      = var.gce_pd_csi_driver
   network_policy         = var.network_policy
+  maintenance_start_time = var.maintenance_start_time
+  maintenance_end_time   = var.maintenance_end_time
+  maintenance_recurrence = var.maintenance_recurrence
 
   # Labels
   cluster_resource_labels = {

--- a/environment/deployments/science-platform/gke/variables.tf
+++ b/environment/deployments/science-platform/gke/variables.tf
@@ -41,9 +41,21 @@ variable "gce_pd_csi_driver" {
 }
 
 variable "maintenance_start_time" {
-  description = "Time window specified for daily maintenance operations in RFC3339 format"
+  description = "Time window start for maintenance operations in RFC3339 format"
   type        = string
   default     = "05:00"
+}
+
+variable "maintenance_end_time" {
+  description = "Time window end for maintenance operations in RFC3339 format"
+  type        = string
+  default     = "09:00"
+}
+
+variable "maintenance_recurrence" {
+  description = "RFC 5545 RRULE for when maintenance windows occur"
+  type        = string
+  default     = "FREQ=DAILY"
 }
 
 variable "network_policy" {

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -21,6 +21,8 @@ module "gke" {
   logging_service                    = var.logging_service
   monitoring_service                 = var.monitoring_service
   maintenance_start_time             = var.maintenance_start_time
+  maintenance_end_time               = var.maintenance_end_time
+  maintenance_recurrence             = var.maintenance_recurrence
   create_service_account             = var.create_service_account
   enable_resource_consumption_export = var.enable_resource_consumption_export
   skip_provisioners                  = var.skip_provisioners

--- a/modules/gke/readme.md
+++ b/modules/gke/readme.md
@@ -55,7 +55,9 @@ module "gke" {
 | ip\_range\_pods | The VPC network to host the cluster in (required) | `string` | `"kubernetes-pods"` | no |
 | ip\_range\_services | The name of the secondary subnet range to use for services | `string` | `"kubernetes-services"` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
-| maintenance\_start\_time | Time window specified for daily maintenance operations in RFC3339 format | `string` | `"05:00"` | no |
+| maintenance\_start\_time | Time window start for maintenance operations in RFC3339 format | `string` | `"05:00"` | no |
+| maintenance\_end\_time | Time window end for maintenance operations in RFC3339 format | `string` | `"09:00"` | no |
+| maintenance\_recurrence | RFC 5545 RRULE for when maintenance windows occur | `string` | `"FREQ=DAILY"` | no |
 | master\_ipv4\_cidr\_block | n/a | `string` | `"172.16.0.0/28"` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | A prefix to the default cluster name | `string` | `"simple"` | no |

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -70,9 +70,21 @@ variable "logging_service" {
 }
 
 variable "maintenance_start_time" {
-  description = "Time window specified for daily maintenance operations in RFC3339 format"
+  description = "Time window start for maintenance operations in RFC3339 format"
   type        = string
   default     = "05:00"
+}
+
+variable "maintenance_end_time" {
+  description = "Time window end for maintenance operations in RFC3339 format"
+  type        = string
+  default     = "09:00"
+}
+
+variable "maintenance_recurrence" {
+  description = "RFC 5545 RRULE for when maintenance windows occur"
+  type        = string
+  default     = "FREQ=DAILY"
 }
 
 variable "enable_intranode_visibility" {


### PR DESCRIPTION
We have to have 48 hours of maintenance in any 32 day interval, so
satisfy that with 12 hours per week.  Plumb the maintenance_*
settings through the module so that they can be set per environment.
data-dev will use midnight to noon UTC Wednesday (5pm to 5am PDT
Tuesday to Wednesday), and (later) int will do the same Thursday
and prod Friday.