### PR TITLE
Fix typo in Kafka nodepool declaration

### DIFF
--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -47,7 +47,7 @@ node_pools = [
   },
   {
     name = "kafka-pool"
-    machine-type = "n2-standard-32"
+    machine_type = "n2-standard-32"
     node_locations     = "us-central1-b"
     local_ssd_count    = 0
     auto_repair        = true


### PR DESCRIPTION
Fixes a typo in the Kafka nodepool declaration. They're getting e2-mediums right now, which are very small.