### PR TITLE
DM-32568: Add taints to the Kafka node pool on data-int

### DIFF
--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -77,6 +77,18 @@ node_pools_labels = {
   }
 }
 
+node_pools_taints = {
+  core-pool = [],
+  dask-pool = []
+  kafka-pool = [
+    {
+      effect = "NoSchedule"
+      key = "kafka",
+      value = "ok"
+    }
+  ]
+}
+
 # TF State declared during pipeline
 # bucket = "lsst-terraform-state"
 # prefix = "qserv/int/gke"

--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -82,7 +82,7 @@ node_pools_taints = {
   dask-pool = []
   kafka-pool = [
     {
-      effect = "NoSchedule"
+      effect = "NO_SCHEDULE"
       key = "kafka",
       value = "ok"
     }

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -62,4 +62,6 @@ module "gke" {
       application_name = var.application_name
     }
   }
+
+  node_pools_taints = var.node_pools_taints
 }

--- a/environment/deployments/science-platform/gke/variables.tf
+++ b/environment/deployments/science-platform/gke/variables.tf
@@ -90,3 +90,12 @@ variable "node_pools_labels" {
     }
   }
 }
+
+variable "node_pools_taints" {
+  type        = map(list(object({ key = string, value = string, effect = string })))
+  description = "Map of lists containing node taints by node-pool name"
+
+  default = {
+    all = []
+  }
+}

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -46,4 +46,5 @@ module "gke" {
   default_max_pods_per_node          = var.default_max_pods_per_node
 
   node_pools_labels = var.node_pools_labels
+  node_pools_taints = var.node_pools_taints
 }

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -234,23 +234,29 @@ variable "node_pools_labels" {
   }
 }
 
+variable "node_pools_taints" {
+  type        = map(list(object({ key = string, value = string, effect = string })))
+  description = "Map of lists containing node taints by node-pool name"
 
-variable "cluster_autoscaling" {
-   type = object({
-     enabled = bool
-     autoscaling_profile = string
-     min_cpu_cores = number
-     max_cpu_cores = number
-     min_memory_gb = number
-     max_memory_gb = number
-   })
-  default = {
-   enabled             = false
-   autoscaling_profile = "BALANCED"
-   min_cpu_cores       = 0
-   max_cpu_cores       = 0
-   min_memory_gb       = 0
-   max_memory_gb       = 0
-   }
+  default = {}
 }
 
+
+variable "cluster_autoscaling" {
+  type = object({
+    enabled             = bool
+    autoscaling_profile = string
+    min_cpu_cores       = number
+    max_cpu_cores       = number
+    min_memory_gb       = number
+    max_memory_gb       = number
+  })
+  default = {
+    enabled             = false
+    autoscaling_profile = "BALANCED"
+    min_cpu_cores       = 0
+    max_cpu_cores       = 0
+    min_memory_gb       = 0
+    max_memory_gb       = 0
+  }
+}


### PR DESCRIPTION
This change adds a taint to the Kafka node pool on the science-platform GKE, integration environment. The taint will help avoid scheduling non-Kafka work onto Kafka nodes.

This required passing the taints through two layers - the modules/gke module, and the environments/science-platform/gke module. I've used exactly the same variable name and type as the upstream terraform-google-kubernetes-engine module.