### PR TITLE
Use bucket names which are more likely to be unique

### DIFF
--- a/environment/deployments/science-platform/alertdb/main.tf
+++ b/environment/deployments/science-platform/alertdb/main.tf
@@ -12,7 +12,7 @@ module "alert_packet_bucket" {
   project_id    = var.project_id
   storage_class = "REGIONAL"
   location      = "us-central1"
-  prefix_name   = "alertdb"
+  prefix_name   = "rubin-alertdb-${var.environment}"
   suffix_name   = ["packets"]
   labels        = var.labels
 
@@ -34,7 +34,7 @@ module "alert_schema_bucket" {
   project_id    = var.project_id
   storage_class = "REGIONAL"
   location      = "us-central1"
-  prefix_name   = "alertdb"
+  prefix_name   = "rubin-alertdb-${var.environment}"
   suffix_name   = ["schemas"]
   labels        = var.labels
 }

--- a/environment/deployments/science-platform/alertdb/variables.tf
+++ b/environment/deployments/science-platform/alertdb/variables.tf
@@ -3,6 +3,11 @@ variable "project_id" {
   type        = string
 }
 
+variable "environment" {
+  description = "The environment the single project belongs to"
+  type        = string
+}
+
 variable "labels" {
   description = "Labels to be attached to the buckets"
   type        = map(any)

--- a/environment/deployments/science-platform/env/dev-alertdb.tfvars
+++ b/environment/deployments/science-platform/env/dev-alertdb.tfvars
@@ -12,4 +12,4 @@ reader_k8s_namespace           = "alert-stream-broker"
 reader_k8s_serviceaccount_name = "alert-database-reader"
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 1
+# Serial: 2

--- a/environment/deployments/science-platform/env/integration-alertdb.tfvars
+++ b/environment/deployments/science-platform/env/integration-alertdb.tfvars
@@ -12,4 +12,4 @@ reader_k8s_namespace           = "alert-stream-broker"
 reader_k8s_serviceaccount_name = "alert-database-reader"
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 1
+# Serial: 2

--- a/environment/deployments/science-platform/env/production-alertdb.tfvars
+++ b/environment/deployments/science-platform/env/production-alertdb.tfvars
@@ -11,4 +11,4 @@ reader_k8s_namespace           = "alert-stream-broker"
 reader_k8s_serviceaccount_name = "alert-database-reader"
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 1
+# Serial: 2


### PR DESCRIPTION
Follow-up after failed runs https://github.com/lsst/idf_deploy/runs/4552457540 and https://github.com/lsst/idf_deploy/runs/4552457535 - we need to include environment (and more) in bucket names to make them unique.