### PR TITLE
[DM-33494] Add GCS bucket for cutouts

### DIFF
--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -86,3 +86,15 @@ variable "backups_enabled" {
   description = "True if backup configuration is enabled"
   default     = false
 }
+
+variable "butler_service_account" {
+  description = "Service account used for Butler GCS access"
+  type        = string
+  default     = "butler-gcs-butler-gcs-data-sa@data-curation-prod-fbdb.iam.gserviceaccount.com"
+}
+
+variable "maximum_cutouts_age" {
+  description = "Age of objects in days before deletion from the temporary cutouts bucket"
+  type        = number
+  default     = 30
+}

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -17,4 +17,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 2
+# Serial: 3


### PR DESCRIPTION
This is rather unfortunately mixed in with CloudSQL because it
needs to reuse the service account created for PostgreSQL access
for GCS bucket access as well.  Object creation access is granted
to the same service account as is currently used for Butler access.
This is temporary until we have client/server Butler.