### PR TITLE
[DM-33494] Add additional IAM binding for vo-cutouts account

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -139,7 +139,8 @@ resource "google_storage_bucket_iam_binding" "cutouts-bucket-ro-iam-binding" {
   bucket  = module.cutouts_bucket.name
   role    = "roles/storage.objectViewer"
   members = [
-    "serviceAccount:${local.cutout_service_account}"
+    "serviceAccount:${local.cutout_service_account}",
+    "serviceAccount:${var.butler_service_account}"
   ]
 }
 

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -169,3 +169,16 @@ resource "google_service_account_iam_binding" "vo-cutouts-iam-binding" {
     "serviceAccount:${var.project_id}.svc.id.goog[vo-cutouts/vo-cutouts]",
   ]
 }
+
+# The vo-cutouts service account must be granted the ability to generate
+# tokens for itself so that it can generate signed GCS URLs starting from
+# the GKE service account token without requiring an exported secret key
+# for the underlying Google service account.
+resource "google_service_account_iam_binding" "vo-cutouts-iam-gcs-binding" {
+  service_account_id = module.service_accounts.service_accounts_map["vo-cutouts"].name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "serviceAccount:${local.cutout_service_account}"
+  ]
+}

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -17,4 +17,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 3
+# Serial: 4

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -17,4 +17,4 @@ db_maintenance_window_hour = 22
 backups_enabled            = true
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 3
+# Serial: 4


### PR DESCRIPTION
We're using workload identity to bind a GKE service account to the
Google service account for vo-cutouts, which in addition to having
Cloud SQL access also has GCS access and needs to be able to
generate signed GCS URLs.

To do URL signing, it must have a private key, but exporting the
private key of a Google service account is deprecated and less secure,
and workload identity does not provide the private key.  The
alternative is to grant the service account the ability to create
tokens for itself (via the role iam.ServiceAccountTokenAccess), which
allows it to use its GKE credentials to bootstrap to a private key
that in turn can generate a pre-signed URL.

Enable this on dev and int.  Tested by manually creating the
equivalent policy on int.