### PR TITLE
Removed legacy cloud storage role

### DIFF
--- a/environment/deployments/panda/env/dev.tfvars
+++ b/environment/deployments/panda/env/dev.tfvars
@@ -18,8 +18,7 @@ activate_apis = [
 project_iam_sa_gcs_access = [
   "roles/logging.logWriter",
   "roles/storage.objectViewer",
-  "roles/artifactregistry.writer",
-  "roles/storage.legacyBucketWriter"
+  "roles/artifactregistry.writer"
 ]
 
 # VPC


### PR DESCRIPTION
Role scope only available at bucket level