### PR TITLE
[DM-33720] Deploy vo-cutouts resources in IDF prod

### DIFF
--- a/environment/deployments/science-platform/env/production-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/production-cloudsql.tfvars
@@ -19,4 +19,4 @@ db_maintenance_window_hour = 22
 backups_enabled            = true
 
 # Increase this number to force Terraform to update the prod environment.
-# Serial: 1
+# Serial: 2


### PR DESCRIPTION
Bump the serial number of the prod Cloud SQL environment so that
the vo-cutouts database, GCS bucket, service account, and service
and service account bindings will be created there.