### PR TITLE
DM-33753: Add times-square Cloud SQL DB

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -25,6 +25,13 @@ resource "random_password" "gafaelfawr" {
   special = false
 }
 
+resource "random_password" "times-square" {
+  length  = 24
+  number  = true
+  upper   = true
+  special = false
+}
+
 resource "random_password" "vo-cutouts" {
   length  = 24
   number  = true
@@ -69,6 +76,11 @@ module "db_science_platform" {
       collation = "en_US.UTF8"
     },
     {
+      name      = "times-square"
+      charset   = "UTF8"
+      collation = "en_US.UTF8"
+    },
+    {
       name      = "vo-cutouts"
       charset   = "UTF8"
       collation = "en_US.UTF8"
@@ -79,6 +91,10 @@ module "db_science_platform" {
     {
       name     = "gafaelfawr"
       password = random_password.gafaelfawr.result
+    },
+    {
+      name     = "times-square"
+      password = random_password.times-square.result
     },
     {
       name     = "vo-cutouts"
@@ -131,7 +147,7 @@ module "service_accounts" {
   project_id    = var.project_id
   display_name  = "PostgreSQL client"
   description   = "Terraform-managed service account for PostgreSQL access"
-  names         = ["gafaelfawr", "vo-cutouts"]
+  names         = ["gafaelfawr", "times-square", "vo-cutouts"]
   project_roles = ["${var.project_id}=>roles/cloudsql.client"]
 }
 
@@ -159,6 +175,15 @@ resource "google_service_account_iam_binding" "gafaelfawr-iam-binding" {
   members = [
     "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]",
     "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-tokens]",
+  ]
+}
+
+resource "google_service_account_iam_binding" "times-square-iam-binding" {
+  service_account_id = module.service_accounts.service_accounts_map["times-square"].name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${var.project_id}.svc.id.goog[times-square/times-square]",
   ]
 }
 

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -17,4 +17,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 4
+# Serial: 5


### PR DESCRIPTION
Times Square is a new RSP service for displaying templated notebooks as webpages, https://sqr-062.lsst.io. It requires a Cloud SQL db as a durable datastore for page settings.

Within the science-platform deployment:

- Added times-square database
- Added times-square db user
- Added times-square service account
- Added times-square-iam-binding
- Incremented deployment serial number

(This PR is parroting existing settings; let me know if they don't make sense!). Times Square will be deployed in a `times-square` Kubernetes namespace.