### PR TITLE
Add domain registration role to shared-services

### DIFF
--- a/environment/foundation/1-org-b/variables.tf
+++ b/environment/foundation/1-org-b/variables.tf
@@ -128,7 +128,7 @@ variable "gcp_square_gke_developer_iam_permissions" {
   ]
 }
 
-// PROJECT ADMINISTRATORS
+// GCP PROJECT ADMINISTRATORS
 
 variable "gcp_qserv_administrators_iam_permissions" {
   description = "List of permissions granted to the group."

--- a/environment/foundation/1-org-b/variables.tf
+++ b/environment/foundation/1-org-b/variables.tf
@@ -174,7 +174,8 @@ variable "gcp_org_administrators_shared_service_iam_permissions" {
   description = "List of permissions granted to the group."
   type        = list(string)
   default = [
-    "roles/storage.admin"
+    "roles/storage.admin",
+    "roles/domains.admin"
   ]
 }
 


### PR DESCRIPTION
Since Cloud Domains is attached to projects and not orgs, shared-services is the right place for it and so shared services admin seems like the right role for that. It also means that   non-DM groups using lsst.cloud (like EPO) can be added to a group with relatively restricted permissions. 