### PR TITLE
DM-34729: Fix IAM policy for the bucket butler-us-central1-dp02-user

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -64,3 +64,4 @@ project_iam_permissions = ["roles/storage.admin", "roles/storagetransfer.admin"]
 data_curation_prod_names = ["butler-gcs-data-sa"]
 
 # Comment to force update
+


### PR DESCRIPTION
Terraform action of the last merge https://github.com/lsst/idf_deploy/pull/423 
failed probably because the bucket didn't exist at the time. Try again. 