### PR TITLE
[DM-35029] Move hips service account out of GKE

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -38,4 +38,4 @@ node_pools_labels = {
 }
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 1
+# Serial: 2

--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -96,5 +96,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 13
-
+# Serial: 14

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -65,22 +65,3 @@ module "gke" {
 
   node_pools_taints = var.node_pools_taints
 }
-
-module "service_accounts" {
-  source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 3.0"
-
-  project_id    = local.project_id
-  display_name  = "HiPS web service"
-  description   = "Terraform-managed service account for GCS access"
-  names         = ["crawlspace-hips"]
-}
-
-resource "google_service_account_iam_binding" "hips-iam-binding" {
-  service_account_id = module.service_accounts.service_accounts_map["crawlspace-hips"].name
-  role               = "roles/iam.workloadIdentityUser"
-
-  members = [
-    "serviceAccount:${local.project_id}.svc.id.goog[hips/hips]",
-  ]
-}

--- a/environment/deployments/science-platform/main.tf
+++ b/environment/deployments/science-platform/main.tf
@@ -33,6 +33,19 @@ resource "google_service_account_iam_member" "gar_sa_wi" {
   member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[cachemachine/cachemachine]"
 }
 
+resource "google_service_account" "hips_sa" {
+  account_id   = "crawlspace-hips"
+  display_name = "HiPS web service"
+  description  = "Terraform-managed service account for GCS access"
+  project      = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "hips_sa_wi" {
+  service_account_id = google_service_account.hips_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[hips/hips]"
+}
+
 module "filestore" {
   source             = "../../../modules/filestore"
   fileshare_capacity = var.fileshare_capacity


### PR DESCRIPTION
The GKE Terraform runner doesn't have permissions to create service
accounts.  Move the service account to the science-platform top level
next to the GAR cachemachine service account and use a similar
construction to set it up.