### PR TITLE
[DM-35028] Update data-curation

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -64,4 +64,4 @@ project_iam_permissions = ["roles/storage.admin", "roles/storagetransfer.admin"]
 data_curation_prod_names = ["butler-gcs-data-sa"]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 2
+# Serial: 3


### PR DESCRIPTION
Apply previous change to add the crawlspace-hips service account
to the ACL on the VISTA HiPS bucket.