### PR TITLE
[DM-35171] Add HiPS bucket for DP0.2

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -64,4 +64,4 @@ project_iam_permissions = ["roles/storage.admin", "roles/storagetransfer.admin"]
 data_curation_prod_names = ["butler-gcs-data-sa"]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 3
+# Serial: 4

--- a/environment/deployments/data-curation/variables.tf
+++ b/environment/deployments/data-curation/variables.tf
@@ -213,8 +213,11 @@ variable "data_curation_prod_names" {
 }
 
 // HiPS
-variable "hips_service_account" {
-  type        = string
-  description = "Service account used for HiPS Butler access"
-  default     = "crawlspace-hips@science-platform-dev-7696.iam.gserviceaccount.com"
+variable "hips_service_accounts" {
+  type        = list(string)
+  description = "Service accounts used for HiPS Butler access"
+  default     = [
+    "serviceAccount:crawlspace-hips@science-platform-dev-7696.iam.gserviceaccount.com",
+    "serviceAccount:crawlspace-hips@science-platform-int-dc5d.iam.gserviceaccount.com"
+  ]
 }

--- a/environment/deployments/science-platform/env/integration.tfvars
+++ b/environment/deployments/science-platform/env/integration.tfvars
@@ -94,4 +94,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 2
+# Serial: 3


### PR DESCRIPTION
Use the naming convention discussed on Slack.  Grant RW access to
the Butler service account we've been using for ease of importing
data (the plan is to remove that access once the data is imported).

Create the crawlspace service account for data-int and add it to
the HiPS ACL list.