### PR TITLE
Add missing fw rule for QServ Operator Connectivity

### DIFF
--- a/environment/deployments/qserv/env/production.tfvars
+++ b/environment/deployments/qserv/env/production.tfvars
@@ -79,6 +79,31 @@ custom_rules_2 = {
   }
 }
 
+custom_rules_3 = {
+  operator-connectivity = {
+    description          = "Deployed with Terraform. QServ Operator Connectivity"
+    direction            = "INGRESS"
+    action               = "allow"
+    ranges               = ["172.23.0.0/28"]
+    sources              = []
+    targets              = ["gke-qserv-prod"]
+    use_service_accounts = false
+    rules = [
+      {
+        protocol = "tcp"
+        ports    = ["9443"]
+      }
+    ]
+
+    extra_attributes = {
+      disabled           = false
+      flow_logs          = false
+      flow_logs_metadata = ""
+    }
+  }
+}
+
+
 # NAT
 address_count = 1
 nat_name      = "cloud-nat"


### PR DESCRIPTION
Hi @dspeck1 , I added a missing fw rule for `qserv-prod`, for "QServ Operator Connectivity", it exists on `qserv-dev` and `qserv-int` but was missing on `qserv-prod`. I think this is a blocker for @fritzm because it prevents Qserv upgrade on  `qserv-prod`. Could you please review it ASAP?

Kind regards