### PR TITLE
Add stable service account to HiPS bucket ACLs

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -63,5 +63,12 @@ project_iam_permissions = ["roles/storage.admin", "roles/storagetransfer.admin"]
 # Butler GCS Access Service Account
 data_curation_prod_names = ["butler-gcs-data-sa"]
 
+# HiPS bucket access service accounts.
+hips_service_accounts = [
+  "serviceAccount:crawlspace-hips@science-platform-dev-7696.iam.gserviceaccount.com",
+  "serviceAccount:crawlspace-hips@science-platform-int-dc5d.iam.gserviceaccount.com",
+  "serviceAccount:crawlspace-hips@science-platform-stable-6994.iam.gserviceaccount.com"
+]
+
 # Increase this number to force Terraform to update the dev environment.
 # Serial: 4

--- a/environment/deployments/data-curation/variables.tf
+++ b/environment/deployments/data-curation/variables.tf
@@ -216,8 +216,5 @@ variable "data_curation_prod_names" {
 variable "hips_service_accounts" {
   type        = list(string)
   description = "Service accounts used for HiPS Butler access"
-  default     = [
-    "serviceAccount:crawlspace-hips@science-platform-dev-7696.iam.gserviceaccount.com",
-    "serviceAccount:crawlspace-hips@science-platform-int-dc5d.iam.gserviceaccount.com"
-  ]
+  default     = []
 }


### PR DESCRIPTION
Also move the account list out of variables.tf and into
production.tfvars, since it's really per-environment configuration
(even though that doesn't matter at the moment for data-curation).