### PR TITLE
[DM-34613] Create Gafaelfawr IAM binding in Firestore project

### DIFF
--- a/environment/deployments/science-platform/firestore/env/dev.tfvars
+++ b/environment/deployments/science-platform/firestore/env/dev.tfvars
@@ -16,7 +16,7 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 8
+# Serial: 9
 
 gafaelfawr_project_id = "science-platform-dev-7696"
 gafaelfawr_sa         = "gafaelfawr@science-platform-dev-7696.iam.gserviceaccount.com"

--- a/environment/deployments/science-platform/firestore/main.tf
+++ b/environment/deployments/science-platform/firestore/main.tf
@@ -19,7 +19,7 @@ module "iam_admin" {
 }
 
 resource "google_project_iam_member" "gafaelfawr-iam-binding" {
-  project = var.gafaelfawr_project_id
+  project = module.project_factory.project_id
   role    = "roles/datastore.user"
   member  = "serviceAccount:${var.gafaelfawr_sa}"
 }


### PR DESCRIPTION
I think this has to exist in the Firestore project, not in the
Gafaelfawr service account project.