### PR TITLE
DM-37189: Add Firestore project for stable

### DIFF
--- a/.github/workflows/rsp-stable-firestore-proj-tf.yaml
+++ b/.github/workflows/rsp-stable-firestore-proj-tf.yaml
@@ -1,0 +1,65 @@
+# Deploys Science Platform Firestore Stable GCP Project with Terraform
+name: 'RSP STABLE FIRESTORE GCP Project'
+
+on:
+  pull_request:
+    paths:
+      - 'environment/deployments/science-platform/firestore/env/production.tfvars'
+  push:
+    paths:
+      - 'environment/deployments/science-platform/firestore/env/production.tfvars'
+    branches:
+      - main
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+
+    # Sets default shell and working directory
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./environment/deployments/science-platform/firestore
+
+    # Checkout the repository to the GitHub Actions runner
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Gcloud CLI setup
+    - name: GCP login
+      uses: google-github-actions/setup-gcloud@v0
+      with:
+        version: '379.0.0'
+        service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        export_default_credentials: true
+
+    # Install terraform
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.13.5
+
+    # Checks for proper terraform code formatting
+    - name: Terraform Fmt
+      run: terraform fmt
+
+     # Initialize a new or existing terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: terraform init -backend-config=bucket=${{ secrets.TERRAFORM_STATE_BUCKET }} -backend-config=prefix=science-platform/firestore/prod
+
+    # Checks that all terraform configuration files adhere to a canonical format
+    - name: Terraform Validate
+      run: terraform validate
+
+    # Generates Terraform execution plan
+    - name: Terraform Plan
+      id: plan
+      run: terraform plan -var-file=env/production.tfvars -no-color
+
+    # On push to main, build or change infrastructure according to terraform configuration files
+    - name: Terraform Apply
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: terraform apply -var-file=env/production.tfvars -auto-approve

--- a/environment/deployments/science-platform/firestore/env/production.tfvars
+++ b/environment/deployments/science-platform/firestore/env/production.tfvars
@@ -1,0 +1,22 @@
+# Project
+environment                 = "stable"
+application_name            = "science-platform"
+folder_id                   = "719717645081"
+budget_amount               = 1000
+budget_alert_spent_percents = [0.7, 0.8, 0.9, 1.0]
+
+
+# Enable Google Artifact Registry, Service Networking, Container Filesystem,
+# and Cloud SQL Admin (required for the Cloud SQL Auth Proxy) in addition to
+# our standard APIs.
+activate_apis = [
+  "stackdriver.googleapis.com",
+  "storage.googleapis.com",
+  "billingbudgets.googleapis.com",
+]
+
+# Increase this number to force Terraform to update the stable environment.
+# Serial: 1
+
+gafaelfawr_project_id = "science-platform-stable-6994"
+gafaelfawr_sa         = "gafaelfawr@science-platform-stable-6994.iam.gserviceaccount.com"


### PR DESCRIPTION
In preparation for switching to COmanage and CILogon for the data.lsst.cloud environment, create a Firestore project for UID and GID tracking following the pattern used for dev and int.