### PR TITLE
DM-38279: Create service account for nublado controller

### DIFF
--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -96,4 +96,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 22
+# Serial: 23

--- a/environment/deployments/science-platform/main.tf
+++ b/environment/deployments/science-platform/main.tf
@@ -46,6 +46,18 @@ resource "google_service_account_iam_member" "gar_sa_wi" {
   member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[cachemachine/cachemachine]"
 }
 
+resource "google_service_account" "nublado_gar_sa" {
+  account_id   = "nublado-controller"
+  display_name = "Terraform-managed service account for GAR access"
+  project      = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "nublado_gar_sa_wi" {
+  service_account_id = google_service_account.nublado_gar_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[nublado/nublado-controller]"
+}
+
 resource "google_service_account" "dns_validator_sa" {
   account_id   = "dns-validator-wi"
   display_name = "Created by Terraform"


### PR DESCRIPTION
The new Nublado lab controller needs to be able to talk to Google Artifact Registry and therefore needs a service account with workload identity enabled.