### PR TITLE
DM-39014: Add dedicated Kafka and Zookeeper node pools in Roundtable

### DIFF
--- a/environment/deployments/roundtable/env/dev-gke.tfvars
+++ b/environment/deployments/roundtable/env/dev-gke.tfvars
@@ -27,14 +27,71 @@ node_pools = [
     enable_secure_boot = true
     disk_size_gb       = "200"
     disk_type          = "pd-ssd"
+  },
+  {
+    name               = "kafka-pool"
+    machine_type       = "n2-standard-8" # 8 vCPU 32GB
+    node_locations     = "us-central1-a,us-central1-b,us-central1-c"
+    local_ssd_count    = 0
+    auto_repair        = true
+    auto_upgrade       = true
+    preemptible        = false
+    autoscaling        = true
+    initial_node_count = 1
+    min_count          = 1
+    max_count          = 100
+    image_type         = "cos_containerd"
+    enable_secure_boot = true
+    disk_size_gb       = "200"
+    disk_type          = "pd-ssd"
+  },
+  {
+    name               = "zookeeper-pool"
+    machine_type       = "n2-standard-8" # 8 vCPU 32GB
+    node_locations     = "us-central1-a,us-central1-b,us-central1-c"
+    local_ssd_count    = 0
+    auto_repair        = true
+    auto_upgrade       = true
+    preemptible        = false
+    autoscaling        = true
+    initial_node_count = 1
+    min_count          = 1
+    max_count          = 100
+    image_type         = "cos_containerd"
+    enable_secure_boot = true
+    disk_size_gb       = "200"
+    disk_type          = "pd-ssd"
   }
 ]
 
 node_pools_labels = {
   core-pool = {
     infrastructure = "ok",
+  },
+  kafka-pool = {
+    kafka = "ok",
+  },
+  kafka-pool = {
+    zookeeper = "ok",
   }
 }
 
+node_pools_taints = {
+  kafka-pool = [
+    {
+      key    = "dedicated"
+      value  = "kafka"
+      effect = "NO_EXECUTE"
+    }
+  ],
+  zookeeper-pool = [
+    {
+      key    = "dedicated"
+      value  = "zookeeper"
+      effect = "NO_EXECUTE"
+    }
+  ]
+}
+
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 1
+# Serial: 2

--- a/environment/deployments/roundtable/env/dev-gke.tfvars
+++ b/environment/deployments/roundtable/env/dev-gke.tfvars
@@ -67,12 +67,6 @@ node_pools = [
 node_pools_labels = {
   core-pool = {
     infrastructure = "ok",
-  },
-  kafka-pool = {
-    kafka = "ok",
-  },
-  kafka-pool = {
-    zookeeper = "ok",
   }
 }
 

--- a/environment/deployments/roundtable/env/production-gke.tfvars
+++ b/environment/deployments/roundtable/env/production-gke.tfvars
@@ -27,6 +27,40 @@ node_pools = [
     initial_node_count = 1
     min_count          = 1
     max_count          = 100
+  },
+  {
+    name               = "kafka-pool"
+    machine_type       = "n2-standard-8" # 8 vCPU 32GB
+    node_locations     = "us-central1-a,us-central1-b,us-central1-c"
+    local_ssd_count    = 0
+    auto_repair        = true
+    auto_upgrade       = true
+    preemptible        = false
+    autoscaling        = true
+    initial_node_count = 1
+    min_count          = 1
+    max_count          = 100
+    image_type         = "cos_containerd"
+    enable_secure_boot = true
+    disk_size_gb       = "200"
+    disk_type          = "pd-ssd"
+  },
+  {
+    name               = "zookeeper-pool"
+    machine_type       = "n2-standard-8" # 8 vCPU 32GB
+    node_locations     = "us-central1-a,us-central1-b,us-central1-c"
+    local_ssd_count    = 0
+    auto_repair        = true
+    auto_upgrade       = true
+    preemptible        = false
+    autoscaling        = true
+    initial_node_count = 1
+    min_count          = 1
+    max_count          = 100
+    image_type         = "cos_containerd"
+    enable_secure_boot = true
+    disk_size_gb       = "200"
+    disk_type          = "pd-ssd"
   }
 ]
 
@@ -34,7 +68,30 @@ node_pools_labels = {
   core-pool = {
     infrastructure = "ok",
   }
+  kafka-pool = {
+    kafka = "ok",
+  },
+  kafka-pool = {
+    zookeeper = "ok",
+  }
 }
 
-# Increase this number to force Terraform to update the dev environment.
-# Serial: 1
+node_pools_taints = {
+  kafka-pool = [
+    {
+      key    = "dedicated"
+      value  = "kafka"
+      effect = "NO_EXECUTE"
+    }
+  ],
+  zookeeper-pool = [
+    {
+      key    = "dedicated"
+      value  = "zookeeper"
+      effect = "NO_EXECUTE"
+    }
+  ]
+}
+
+# Increase this number to force Terraform to update the production environment.
+# Serial: 2

--- a/environment/deployments/roundtable/env/production-gke.tfvars
+++ b/environment/deployments/roundtable/env/production-gke.tfvars
@@ -68,12 +68,6 @@ node_pools_labels = {
   core-pool = {
     infrastructure = "ok",
   }
-  kafka-pool = {
-    kafka = "ok",
-  },
-  kafka-pool = {
-    zookeeper = "ok",
-  }
 }
 
 node_pools_taints = {


### PR DESCRIPTION
These node pools include taints to ensure that only Kafka or Zookeeper processes run on these nodes.