### PR TITLE
Add Butler database access for data-dev

### DIFF
--- a/environment/deployments/panda/env/dev.tfvars
+++ b/environment/deployments/panda/env/dev.tfvars
@@ -236,5 +236,4 @@ bucket_policy_only = {
 }
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 2
-
+# Serial: 3

--- a/environment/deployments/panda/main.tf
+++ b/environment/deployments/panda/main.tf
@@ -31,6 +31,13 @@ resource "google_project_iam_member" "sa-gcs-access" {
   member   = "serviceAccount:gcs-access@panda-dev-1a74.iam.gserviceaccount.com"
 }
 
+// Grant access to the service account used in data-dev.lsst.cloud to
+// access the Butler repository database.
+resource "google_project_iam_binding" "data-dev-iam-binding" {
+  role    = "roles/cloudsql.client"
+  members = var.cross_project_service_accounts
+}
+
 module "service_account_cluster" {
   source     = "terraform-google-modules/service-accounts/google"
   version    = "~> 2.0"

--- a/environment/deployments/panda/variables.tf
+++ b/environment/deployments/panda/variables.tf
@@ -99,6 +99,14 @@ variable "project_iam_sa_gcs_access" {
   default     = []
 }
 
+variable "cross_project_service_accounts" {
+  description = "Service account granted database access"
+  type        = list(string)
+  default     = [
+    "sqlproxy-butler-int@science-platform-dev-7696.iam.gserviceaccount.com"
+  ]
+}
+
 # VPC
 
 variable "network_name" {


### PR DESCRIPTION
To give data-dev.lsst.cloud the same access to the Butler database used by data-int.lsst.cloud as that environment, grant the service account used by the Cloud SQL Proxy running on data-dev the cloudsql.client role.