### PR TITLE
Add serviceAccount prefix for Butler access

### DIFF
--- a/environment/deployments/panda/variables.tf
+++ b/environment/deployments/panda/variables.tf
@@ -103,7 +103,7 @@ variable "cross_project_service_accounts" {
   description = "Service account granted database access"
   type        = list(string)
   default     = [
-    "sqlproxy-butler-int@science-platform-dev-7696.iam.gserviceaccount.com"
+    "serviceAccount:sqlproxy-butler-int@science-platform-dev-7696.iam.gserviceaccount.com"
   ]
 }
 


### PR DESCRIPTION
When granting data-dev access to the panda-dev Butler, add the missing serviceAccount prefix to the service account name.