### PR TITLE
tickets/DM-41550: Add Git LFS objects

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -70,5 +70,15 @@ hips_service_accounts = [
   "serviceAccount:crawlspace-hips@science-platform-stable-6994.iam.gserviceaccount.com"
 ]
 
-# Increase this number to force Terraform to update the dev environment.
-# Serial: 4
+# Git LFS bucket access service accounts (RW).
+git_lfs_rw_service_accounts = [
+  "serviceAccount:git-lfs-rw@roundtable-prod-f6fd.iam.gserviceaccount.com"
+]
+
+# Git LFS bucket access service accounts (RW).
+git_lfs_ro_service_accounts = [
+  "serviceAccount:git-lfs-ro@roundtable-prod-f6fd.iam.gserviceaccount.com"
+]
+
+# Increase this number to force Terraform to update the production environment.
+# Serial: 5

--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -80,5 +80,15 @@ git_lfs_ro_service_accounts = [
   "serviceAccount:git-lfs-ro@roundtable-prod-f6fd.iam.gserviceaccount.com"
 ]
 
+# Git LFS bucket access service accounts (Dev, RW).
+git_lfs_rw_dev_service_accounts = [
+  "serviceAccount:git-lfs-rw@roundtable-dev-abe2.iam.gserviceaccount.com"
+]
+
+# Git LFS bucket access service accounts (Dev, RW).
+git_lfs_ro_dev_service_accounts = [
+  "serviceAccount:git-lfs-ro@roundtable-dev-abe2.iam.gserviceaccount.com"
+]
+
 # Increase this number to force Terraform to update the production environment.
 # Serial: 5

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -167,6 +167,38 @@ resource "google_storage_bucket_iam_binding" "dp02-hips-bucket-ro-iam-binding" {
   members = var.hips_service_accounts
 }
 
+// Git LFS Storage Bucket
+module "storage_bucket_5" {
+  source        = "../../../modules/bucket"
+  project_id    = module.project_factory.project_id
+  storage_class = "REGIONAL"
+  location      = "us-central1"
+  suffix_name   = ["git-lfs"]
+  prefix_name   = "rubin"
+  versioning = {
+    git-lfs = false
+  }
+  force_destroy = {
+    git-lfs = false
+  }
+  labels = {
+    environment = var.environment
+    application = "giftless"
+  }
+}
+// RO storage access to Git-LFS bucket
+resource "google_storage_bucket_iam_binding" "git-lfs-bucket-ro-iam-binding" {
+  bucket  = module.storage_bucket_5.name
+  role    = "roles/storage.objectViewer"
+  members = var.git_lfs_ro_service_accounts
+}
+// RW storage access to Git-LFS bucket
+resource "google_storage_bucket_iam_binding" "git-lfs-bucket-rw-iam-binding" {
+  bucket  = module.storage_bucket_5.name
+  role    = "roles/storage.objectAdmin"
+  members = var.git_lfs_rw_service_accounts
+}
+
 #---------------------------------------------------------------
 // Data Curation Prod
 #---------------------------------------------------------------

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -225,7 +225,7 @@ resource "google_storage_bucket_iam_binding" "git-lfs-bucket-dev-ro-iam-binding"
   members = var.git_lfs_ro_dev_service_accounts
 }
 // RW storage access to Git-LFS Dev bucket
-resource "google_storage_bucket_iam_binding" "git-lfs-bucket-rw-iam-binding" {
+resource "google_storage_bucket_iam_binding" "git-lfs-bucket-dev-rw-iam-binding" {
   bucket  = module.storage_bucket_6.name
   role    = "roles/storage.objectAdmin"
   members = var.git_lfs_rw_dev_service_accounts

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -167,7 +167,7 @@ resource "google_storage_bucket_iam_binding" "dp02-hips-bucket-ro-iam-binding" {
   members = var.hips_service_accounts
 }
 
-// Git LFS Storage Bucket
+// Git LFS Storage Bucket (Prod)
 module "storage_bucket_5" {
   source        = "../../../modules/bucket"
   project_id    = module.project_factory.project_id
@@ -197,6 +197,38 @@ resource "google_storage_bucket_iam_binding" "git-lfs-bucket-rw-iam-binding" {
   bucket  = module.storage_bucket_5.name
   role    = "roles/storage.objectAdmin"
   members = var.git_lfs_rw_service_accounts
+}
+
+// Git LFS Storage Bucket (Dev)
+module "storage_bucket_6" {
+  source        = "../../../modules/bucket"
+  project_id    = module.project_factory.project_id
+  storage_class = "REGIONAL"
+  location      = "us-central1"
+  suffix_name   = ["git-lfs-dev"]
+  prefix_name   = "rubin"
+  versioning = {
+    git-lfs-dev = false
+  }
+  force_destroy = {
+    git-lfs-dev = false
+  }
+  labels = {
+    environment = var.environment
+    application = "giftless"
+  }
+}
+// RO storage access to Git-LFS Dev bucket
+resource "google_storage_bucket_iam_binding" "git-lfs-bucket-dev-ro-iam-binding" {
+  bucket  = module.storage_bucket_6.name
+  role    = "roles/storage.objectViewer"
+  members = var.git_lfs_ro_dev_service_accounts
+}
+// RW storage access to Git-LFS Dev bucket
+resource "google_storage_bucket_iam_binding" "git-lfs-bucket-rw-iam-binding" {
+  bucket  = module.storage_bucket_6.name
+  role    = "roles/storage.objectAdmin"
+  members = var.git_lfs_rw_dev_service_accounts
 }
 
 #---------------------------------------------------------------

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -195,7 +195,7 @@ resource "google_storage_bucket_iam_binding" "git-lfs-bucket-ro-iam-binding" {
 // RW storage access to Git-LFS bucket
 resource "google_storage_bucket_iam_binding" "git-lfs-bucket-rw-iam-binding" {
   bucket  = module.storage_bucket_5.name
-  role    = "roles/storage.objectAdmin"
+  role    = "roles/storage.objectUser"
   members = var.git_lfs_rw_service_accounts
 }
 
@@ -227,7 +227,7 @@ resource "google_storage_bucket_iam_binding" "git-lfs-bucket-dev-ro-iam-binding"
 // RW storage access to Git-LFS Dev bucket
 resource "google_storage_bucket_iam_binding" "git-lfs-bucket-dev-rw-iam-binding" {
   bucket  = module.storage_bucket_6.name
-  role    = "roles/storage.objectAdmin"
+  role    = "roles/storage.objectUser"
   members = var.git_lfs_rw_dev_service_accounts
 }
 

--- a/environment/deployments/data-curation/variables.tf
+++ b/environment/deployments/data-curation/variables.tf
@@ -232,3 +232,17 @@ variable "git_lfs_rw_service_accounts" {
   description = "Service accounts used for Git-LFS Giftless access (RW)"
   default     = []
 }
+
+// Git LFS RO
+variable "git_lfs_ro_dev_service_accounts" {
+  type        = list(string)
+  description = "Service accounts used for Git-LFS Giftless Dev access (RO)"
+  default     = []
+}
+
+// Git LFS RW
+variable "git_lfs_rw_dev_service_accounts" {
+  type        = list(string)
+  description = "Service accounts used for Git-LFS Giftless Dev access (RW)"
+  default     = []
+}

--- a/environment/deployments/data-curation/variables.tf
+++ b/environment/deployments/data-curation/variables.tf
@@ -218,3 +218,17 @@ variable "hips_service_accounts" {
   description = "Service accounts used for HiPS Butler access"
   default     = []
 }
+
+// Git LFS RO
+variable "git_lfs_ro_service_accounts" {
+  type        = list(string)
+  description = "Service accounts used for Git-LFS Giftless access (RO)"
+  default     = []
+}
+
+// Git LFS RW
+variable "git_lfs_rw_service_accounts" {
+  type        = list(string)
+  description = "Service accounts used for Git-LFS Giftless access (RW)"
+  default     = []
+}

--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -70,4 +70,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 2
+# Serial: 3

--- a/environment/deployments/roundtable/env/production.tfvars
+++ b/environment/deployments/roundtable/env/production.tfvars
@@ -68,4 +68,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the prod environment.
-# Serial: 2
+# Serial: 3

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -21,6 +21,32 @@ module "iam_admin" {
   member                  = "gcp-${var.application_name}-administrators@lsst.cloud"
 }
 
+resource "google_service_account" "git_lfs_rw_sa" {
+  account_id   = "git-lfs-rw"
+  display_name = "Git LFS (RW)"
+  description  = "Terraform-managed service account for Git LFS RW access"
+  project      = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "git_lfs_rw_sa_wi" {
+  service_account_id = google_service_account.git_lfs_rw_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[git-lfs/rw]"
+}
+
+resource "google_service_account" "git_lfs_ro_sa" {
+  account_id   = "git-lfs-ro"
+  display_name = "Git LFS (RO)"
+  description  = "Terraform-managed service account for Git LFS RO access"
+  project      = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "git_lfs_ro_sa_wi" {
+  service_account_id = google_service_account.git_lfs_ro_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[git-lfs/ro]"
+}
+
 module "service_account_cluster" {
   source     = "terraform-google-modules/service-accounts/google"
   version    = "~> 2.0"

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -31,7 +31,7 @@ resource "google_service_account" "git_lfs_rw_sa" {
 resource "google_service_account_iam_member" "git_lfs_rw_sa_wi" {
   service_account_id = google_service_account.git_lfs_rw_sa.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[git-lfs/rw]"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-rw]"
 }
 
 resource "google_service_account" "git_lfs_ro_sa" {
@@ -44,7 +44,7 @@ resource "google_service_account" "git_lfs_ro_sa" {
 resource "google_service_account_iam_member" "git_lfs_ro_sa_wi" {
   service_account_id = google_service_account.git_lfs_ro_sa.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[git-lfs/ro]"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-ro]"
 }
 
 module "service_account_cluster" {


### PR DESCRIPTION
Add a Git LFS storage bucket in data-curation-prod and add service accounts to access it RO and RW in roundtable-prod.