### PR TITLE
tickets/DM-41550B: allow git lfs accounts to sign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # .json files
 *.json
+
+# Mac desktop info
+.DS_Store

--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -70,4 +70,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 3
+# Serial: 4

--- a/environment/deployments/roundtable/env/production.tfvars
+++ b/environment/deployments/roundtable/env/production.tfvars
@@ -68,4 +68,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the prod environment.
-# Serial: 3
+# Serial: 4

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -34,10 +34,10 @@ resource "google_service_account_iam_member" "git_lfs_rw_sa_wi" {
   member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-rw]"
 }
 
-# The git-lfs-rw service account must be granted the ability to generate
-# tokens for itself so that it can generate signed GCS URLs starting from
-# the GKE service account token without requiring an exported secret key
-# for the underlying Google service account.
+# The git-lfs service accounts must be granted the ability to generate
+# tokens for themselves so that they can generate signed GCS URLs
+# starting from the GKE service account token without requiring an
+# exported secret key for the underlying Google service account.
 resource "google_service_account_iam_binding" "git-lfs-rw-gcs-binding" {
   service_account_id = google_service_account.git_lfs_rw_sa.name
   role               = "roles/iam.serviceAccountTokenCreator"
@@ -58,6 +58,15 @@ resource "google_service_account_iam_member" "git_lfs_ro_sa_wi" {
   service_account_id = google_service_account.git_lfs_ro_sa.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-ro]"
+}
+
+resource "google_service_account_iam_binding" "git-lfs-ro-gcs-binding" {
+  service_account_id = google_service_account.git_lfs_ro_sa.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-ro]"
+  ]
 }
 
 module "service_account_cluster" {

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -34,6 +34,19 @@ resource "google_service_account_iam_member" "git_lfs_rw_sa_wi" {
   member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-rw]"
 }
 
+# The git-lfs-rw service account must be granted the ability to generate
+# tokens for itself so that it can generate signed GCS URLs starting from
+# the GKE service account token without requiring an exported secret key
+# for the underlying Google service account.
+resource "google_service_account_iam_binding" "git-lfs-rw-gcs-binding" {
+  service_account_id = google_service_account.git_lfs_rw_sa.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+
+  members = [
+    "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-rw]"
+  ]
+}
+
 resource "google_service_account" "git_lfs_ro_sa" {
   account_id   = "git-lfs-ro"
   display_name = "Git LFS (RO)"


### PR DESCRIPTION
The giftless implementation uses signed URLS; hence we must allow the SA to sign.