### PR TITLE
Add Workload Identity mappings for filestore backup

### DIFF
--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -96,4 +96,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 23
+# Serial: 24

--- a/environment/deployments/science-platform/main.tf
+++ b/environment/deployments/science-platform/main.tf
@@ -34,6 +34,25 @@ resource "google_service_account_iam_member" "datalinker_sa_wi" {
   member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[datalinker/datalinker]"
 }
 
+resource "google_service_account" "filestore_tool_sa" {
+  account_id   = "filestore-tool"
+  display_name = "filestore tool account"
+  description  = "Terraform-managed service account for Filestore access"
+  project      = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "filestore_tool_sa_wi" {
+  service_account_id = google_service_account.filestore_tool_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[filestore-backup/filestore-backup]"
+}
+
+resource "google_project_iam_member" "filestore_tool_sa_file" {
+  role               = "roles/file.editor"
+  member             = "serviceAccount:${google_service_account.filestore_tool_sa.email}"
+  project            = module.project_factory.project_id
+}
+
 resource "google_service_account" "gar_sa" {
   account_id   = "cachemachine-wi"
   display_name = "Created by Terraform"


### PR DESCRIPTION
This should create a new service account in each environment, assign it the file.editor role, and bind it to the filestore-backup SA in the K8s namespace of the same name.