### PR TITLE
DM-42384: Update Gafaelfawr service accounts

### DIFF
--- a/environment/deployments/roundtable/cloudsql/main.tf
+++ b/environment/deployments/roundtable/cloudsql/main.tf
@@ -82,6 +82,6 @@ resource "google_service_account_iam_binding" "gafaelfawr-iam-binding" {
 
   members = [
     "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]",
-    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-tokens]",
+    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]",
   ]
 }

--- a/environment/deployments/roundtable/env/dev-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/dev-cloudsql.tfvars
@@ -10,4 +10,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 3
+# Serial: 4

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -198,7 +198,7 @@ resource "google_service_account_iam_binding" "gafaelfawr-iam-binding" {
 
   members = [
     "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]",
-    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-tokens]",
+    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]",
   ]
 }
 

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -19,4 +19,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 8
+# Serial: 9


### PR DESCRIPTION
The separate gafaelfawr-tokens service account no longer needs IAM bindings, since the other components of Gafaelfawr now use a stand-alone Cloud SQL Proxy that uses the same service account as Gafaelfawr. Add a gafaelfawr-schema-update service account with Cloud SQL access, since it will be used to do schema migrations.