### PR TITLE
DM-42714: Convert to new workload identity setup

### DIFF
--- a/environment/deployments/roundtable/cloudsql/main.tf
+++ b/environment/deployments/roundtable/cloudsql/main.tf
@@ -76,12 +76,14 @@ module "service_accounts" {
   project_roles = ["${var.project_id}=>roles/cloudsql.client"]
 }
 
-resource "google_service_account_iam_binding" "gafaelfawr-iam-binding" {
+resource "google_service_account_iam_member" "gafaelfawr_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["gafaelfawr"].name
   role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]"
+}
 
-  members = [
-    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]",
-    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]",
-  ]
+resource "google_service_account_iam_member" "gafaelfawr_schema_update_sa_wi" {
+  service_account_id = module.service_accounts.service_accounts_map["gafaelfawr"].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]"
 }

--- a/environment/deployments/roundtable/env/dev-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/dev-cloudsql.tfvars
@@ -10,4 +10,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 4
+# Serial: 5

--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -72,4 +72,4 @@ activate_apis = [
 vault_server_bucket_suffix = "vault-server-dev"
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 9
+# Serial: 10

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -107,20 +107,21 @@ resource "google_service_account" "vault_server_sa" {
 
 // Use Workload Identity to have the service run as the appropriate service
 // account (bound to a Kubernetes service account)
-resource "google_project_iam_member" "vault_server_sa_wi" {
-  project = module.project_factory.project_id
-  role    = "roles/iam.workloadIdentityUser"
-  member  = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[vault/vault]"
+resource "google_service_account_iam_member" "vault_server_sa_wi" {
+  service_account_id = google_service_account.vault_server_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[vault/vault]"
 }
 
-// The Vault service account must be granted the roles Cloud KMS Viewer and
-// Cloud KMS CryptoKey Encrypter/Decrypter
+// The Vault service account must be granted the roles Cloud KMS Viewer
+// and Cloud KMS CryptoKey Encrypter/Decrypter. Note that this grants
+// access to every KMS key in the project, which is not ideal and should
+// be restricted to only the Vault keys.
 resource "google_project_iam_member" "vault_server_viewer_sa" {
   project = module.project_factory.project_id
   role    = "roles/cloudkms.viewer"
   member  = "serviceAccount:vault-server@${module.project_factory.project_id}.iam.gserviceaccount.com"
 }
-
 resource "google_project_iam_member" "vault_server_cryptokey_sa" {
   project = module.project_factory.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
@@ -208,24 +209,22 @@ resource "google_service_account" "git_lfs_rw_sa" {
   project      = module.project_factory.project_id
 }
 
-
-
 # Use Workload Identity to have the service run as the appropriate service
 # account (bound to a Kubernetes service account)
-resource "google_project_iam_member" "git_lfs_rw_sa_wi" {
-  project = module.project_factory.project_id
-  role    = "roles/iam.workloadIdentityUser"
-  member  = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-rw]"
+resource "google_service_account_iam_member" "git_lfs_rw_sa_wi" {
+  service_account_id = google_service_account.git_lfs_rw_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-rw]"
 }
 
 # The git-lfs service accounts must be granted the ability to generate
-# tokens for themselves so that they can generate signed GCS URLs
-# starting from the GKE service account token without requiring an
-# exported secret key for the underlying Google service account.
-resource "google_project_iam_member" "git_lfs_rw_gcs_sa" {
-  project = module.project_factory.project_id
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:git-lfs-rw@${module.project_factory.project_id}.iam.gserviceaccount.com"
+# tokens for themselves so that they can generate signed GCS URLs starting
+# from the GKE service account token without requiring an exported secret
+# key for the underlying Google service account.
+resource "google_service_account_iam_member" "git_lfs_rw_gcs_sa" {
+  service_account_id = google_service_account.git_lfs_rw_sa.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:git-lfs-rw@${module.project_factory.project_id}.iam.gserviceaccount.com"
 }
 
 # Service account for Git LFS read-only
@@ -237,17 +236,17 @@ resource "google_service_account" "git_lfs_ro_sa" {
 }
 
 # See above, but for read-only account
-resource "google_project_iam_member" "git_lfs_ro_sa_wi" {
-  project = module.project_factory.project_id
-  role    = "roles/iam.workloadIdentityUser"
-  member  = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-ro]"
+resource "google_service_account_iam_member" "git_lfs_ro_sa_wi" {
+  service_account_id = google_service_account.git_lfs_ro_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[giftless/git-lfs-ro]"
 }
 
 # See above, but for read-only account
-resource "google_project_iam_member" "git_lfs_ro_gcs" {
-  project = module.project_factory.project_id
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:git-lfs-ro@${module.project_factory.project_id}.iam.gserviceaccount.com"
+resource "google_service_account_iam_member" "git_lfs_ro_gcs" {
+  service_account_id = google_service_account.git_lfs_ro_sa.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:git-lfs-ro@${module.project_factory.project_id}.iam.gserviceaccount.com"
 }
 
 

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -192,52 +192,42 @@ resource "google_storage_bucket_iam_binding" "cutouts-bucket-rw-iam-binding" {
   ]
 }
 
-resource "google_service_account_iam_binding" "gafaelfawr-iam-binding" {
+resource "google_service_account_iam_member" "gafaelfawr_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["gafaelfawr"].name
   role               = "roles/iam.workloadIdentityUser"
-
-  members = [
-    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]",
-    "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]",
-  ]
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]"
 }
 
-resource "google_service_account_iam_binding" "nublado-iam-binding" {
+resource "google_service_account_iam_member" "gafaelfawr_schema_update_wi" {
+  service_account_id = module.service_accounts.service_accounts_map["gafaelfawr"].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]"
+}
+
+resource "google_service_account_iam_member" "nublado_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["nublado"].name
   role               = "roles/iam.workloadIdentityUser"
-
-  members = [
-    "serviceAccount:${var.project_id}.svc.id.goog[nublado/cloud-sql-proxy]",
-  ]
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[nublado/cloud-sql-proxy]"
 }
 
-resource "google_service_account_iam_binding" "times-square-iam-binding" {
+resource "google_service_account_iam_member" "times_square_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["times-square"].name
   role               = "roles/iam.workloadIdentityUser"
-
-  members = [
-    "serviceAccount:${var.project_id}.svc.id.goog[times-square/times-square]",
-  ]
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[times-square/times-square]"
 }
 
-resource "google_service_account_iam_binding" "vo-cutouts-iam-binding" {
+resource "google_service_account_iam_member" "vo_cutouts_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["vo-cutouts"].name
   role               = "roles/iam.workloadIdentityUser"
-
-  members = [
-    "serviceAccount:${var.project_id}.svc.id.goog[vo-cutouts/vo-cutouts]",
-  ]
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[vo-cutouts/vo-cutouts]"
 }
 
 # The vo-cutouts service account must be granted the ability to generate
 # tokens for itself so that it can generate signed GCS URLs starting from
 # the GKE service account token without requiring an exported secret key
 # for the underlying Google service account.
-resource "google_service_account_iam_binding" "vo-cutouts-iam-gcs-binding" {
+resource "google_service_account_iam_member" "vo_cutouts_sa_token" {
   service_account_id = module.service_accounts.service_accounts_map["vo-cutouts"].name
   role               = "roles/iam.serviceAccountTokenCreator"
-
-  members = [
-    "serviceAccount:${local.cutout_service_account}"
-  ]
+  member             = "serviceAccount:${local.cutout_service_account}"
 }

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -19,4 +19,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 9
+# Serial: 10


### PR DESCRIPTION
Use google_service_account_iam_member instead of
google_service_account_iam_binding to set up workload identity. Narrow the grant of bindings for the vault and git-lfs service accounts to just the Google service accounts they should be using.