### PR TITLE
Added ssotap uws database in CloudSQL / Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ The runbook directory is used for documentation.
 
 ## Where to Begin
 
-To start, you will need to go into the [foundation](./environment/foundation) directory. This directoy is the building block to deploying a solid and secure GCP foundation. The foundation directory has it's own [readme](./environment/foundation/readme.md) with steps.
+To start, you will need to go into the [foundation](./environment/foundation) directory. This directoy is the building block to deploying a solid and secure GCP foundation. The foundation directory has its own [readme](./environment/foundation/readme.md) with steps.
 
 ## Where to Continue
 
 After all the steps have been completed from the [foundation](./environment/foundation) directory, next is day-to-day operations. Most of the time, deployments are decentralized meaning a project is created and handed over to a PI or researcher to be used for their initiatives. Terraform may never be used again to manage the project, but is used for consistency and repeatability.
 
-To build new projects with new infrastructure, these should be built under the [modules](./modules) directory. To seperate out different inputs or to have different environments these will go under the [deployments](./environment/deployments) directory. Additional folders under deployments can be used if desired.
+To build new projects with new infrastructure, these should be built under the [modules](./modules) directory. To separate out different inputs or to have different environments these will go under the [deployments](./environment/deployments) directory. Additional folders under deployments can be used if desired.
 
 ---
 ## Runbook
 
 ### [Foundation Terraform](./runbook/update-foundations.md)
 
-The GCP Organization, Organization Policies, Organization Level IAM, projects, monitoring, and logging are in the Foundation Terraform code and GitHub Actions.Input below for creating folders, modifying IAM roles,and modifiying Projects created by Terraform.  Also below is how to manually create GCP projects in the scratch folder.
+The GCP Organization, Organization Policies, Organization Level IAM, projects, monitoring, and logging are in the Foundation Terraform code and GitHub Actions. Input below for creating folders, modifying IAM roles and modifiying Projects created by Terraform.  Also below is how to manually create GCP projects in the scratch folder.
 
 ## Folders
 * [Folder Changes](./runbook/update-foundations.md#example-of-folder-update)

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -54,6 +54,13 @@ resource "random_password" "vo-cutouts" {
   special = false
 }
 
+resource "random_password" "ssotap-uws" {
+  length  = 24
+  number  = true
+  upper   = true
+  special = false
+}
+
 data "google_compute_network" "network" {
   name    = var.network
   project = var.project_id
@@ -104,6 +111,11 @@ module "db_science_platform" {
       name      = "vo-cutouts"
       charset   = "UTF8"
       collation = "en_US.UTF8"
+    },
+    {
+      name      = "ssotap-uws"
+      charset   = "UTF8"
+      collation = "en_US.UTF8"
     }
   ]
 
@@ -123,6 +135,10 @@ module "db_science_platform" {
     {
       name     = "vo-cutouts"
       password = random_password.vo-cutouts.result
+    },
+    {
+      name     = "ssotap-uws"
+      password = random_password.ssotap-uws.result
     }
   ]
 
@@ -171,7 +187,7 @@ module "service_accounts" {
   project_id    = var.project_id
   display_name  = "PostgreSQL client"
   description   = "Terraform-managed service account for PostgreSQL access"
-  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts"]
+  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts", "ssotap-uws"]
   project_roles = ["${var.project_id}=>roles/cloudsql.client"]
 }
 
@@ -220,6 +236,12 @@ resource "google_service_account_iam_member" "vo_cutouts_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["vo-cutouts"].name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[vo-cutouts/vo-cutouts]"
+}
+
+resource "google_service_account_iam_member" "ssotap_uws_sa_wi" {
+  service_account_id = module.service_accounts.service_accounts_map["ssotap-uws"].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[ssotap-uws/ssotap-uws]"
 }
 
 # The vo-cutouts service account must be granted the ability to generate

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -54,7 +54,7 @@ resource "random_password" "vo-cutouts" {
   special = false
 }
 
-resource "random_password" "ssotap-uws" {
+resource "random_password" "ssotap" {
   length  = 24
   number  = true
   upper   = true
@@ -113,7 +113,7 @@ module "db_science_platform" {
       collation = "en_US.UTF8"
     },
     {
-      name      = "ssotap-uws"
+      name      = "ssotap"
       charset   = "UTF8"
       collation = "en_US.UTF8"
     }
@@ -137,8 +137,8 @@ module "db_science_platform" {
       password = random_password.vo-cutouts.result
     },
     {
-      name     = "ssotap-uws"
-      password = random_password.ssotap-uws.result
+      name     = "ssotap"
+      password = random_password.ssotap.result
     }
   ]
 
@@ -187,7 +187,7 @@ module "service_accounts" {
   project_id    = var.project_id
   display_name  = "PostgreSQL client"
   description   = "Terraform-managed service account for PostgreSQL access"
-  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts", "ssotap-uws"]
+  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts", "ssotap"]
   project_roles = ["${var.project_id}=>roles/cloudsql.client"]
 }
 
@@ -238,10 +238,10 @@ resource "google_service_account_iam_member" "vo_cutouts_sa_wi" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[vo-cutouts/vo-cutouts]"
 }
 
-resource "google_service_account_iam_member" "ssotap_uws_sa_wi" {
-  service_account_id = module.service_accounts.service_accounts_map["ssotap-uws"].name
+resource "google_service_account_iam_member" "ssotap_sa_wi" {
+  service_account_id = module.service_accounts.service_accounts_map["ssotap"].name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.project_id}.svc.id.goog[ssotap-uws/ssotap-uws]"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[ssotap/ssotap]"
 }
 
 # The vo-cutouts service account must be granted the ability to generate

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -19,4 +19,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 10
+# Serial: 11


### PR DESCRIPTION
Added SSO UWS database to CloudSQL on the dev project.
I've named the new database ssotap-uws. Alternatives were "sso-tap-uws" and "ssotap", but I wanted to match the application name, and then add "-uws" to it in case we want to add other databases for that application later.

Updated the serial number dev-cloudsql.tfvars
Also fixed a couple typos in the README