### PR TITLE
DM-44606: Update permissions for vo-cutouts

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -196,15 +196,14 @@ resource "google_storage_bucket_iam_binding" "cutouts-bucket-ro-iam-binding" {
   role   = "roles/storage.objectViewer"
   members = [
     "serviceAccount:${local.cutout_service_account}",
-    "serviceAccount:${var.butler_service_account}"
   ]
 }
 
 resource "google_storage_bucket_iam_binding" "cutouts-bucket-rw-iam-binding" {
   bucket = module.cutouts_bucket.name
-  role   = "roles/storage.objectCreator"
+  role   = "roles/storage.legacyBucketWriter"
   members = [
-    "serviceAccount:${var.butler_service_account}"
+    "serviceAccount:${local.cutout_service_account}"
   ]
 }
 

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -19,4 +19,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 11
+# Serial: 12


### PR DESCRIPTION
vo-cutouts now does everything with its own credentials and workload identity and no longer uses the Butler service account. Grant it legacyBucketWriter as well (for some reason, we need the legacy version or the backend code doesn't work).