### PR TITLE
Create TAP cloudsql database on dev

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -61,6 +61,13 @@ resource "random_password" "ssotap" {
   special = false
 }
 
+resource "random_password" "tap" {
+  length  = 24
+  number  = true
+  upper   = true
+  special = false
+}
+
 data "google_compute_network" "network" {
   name    = var.network
   project = var.project_id
@@ -116,6 +123,11 @@ module "db_science_platform" {
       name      = "ssotap"
       charset   = "UTF8"
       collation = "en_US.UTF8"
+    },
+    {
+      name      = "tap"
+      charset   = "UTF8"
+      collation = "en_US.UTF8"
     }
   ]
 
@@ -139,6 +151,10 @@ module "db_science_platform" {
     {
       name     = "ssotap"
       password = random_password.ssotap.result
+    },
+    {
+      name     = "tap"
+      password = random_password.tap.result
     }
   ]
 
@@ -187,7 +203,7 @@ module "service_accounts" {
   project_id    = var.project_id
   display_name  = "PostgreSQL client"
   description   = "Terraform-managed service account for PostgreSQL access"
-  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts", "ssotap"]
+  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts", "ssotap", "tap"]
   project_roles = ["${var.project_id}=>roles/cloudsql.client"]
 }
 
@@ -241,6 +257,12 @@ resource "google_service_account_iam_member" "ssotap_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["ssotap"].name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[ssotap/ssotap]"
+}
+
+resource "google_service_account_iam_member" "tap_sa_wi" {
+  service_account_id = module.service_accounts.service_accounts_map["tap"].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[tap/tap]"
 }
 
 # The vo-cutouts service account must be granted the ability to generate

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -61,7 +61,7 @@ resource "random_password" "ssotap" {
   special = false
 }
 
-resource "random_password" "tap" {
+resource "random_password" "obstap" {
   length  = 24
   number  = true
   upper   = true
@@ -125,7 +125,7 @@ module "db_science_platform" {
       collation = "en_US.UTF8"
     },
     {
-      name      = "tap"
+      name      = "obstap"
       charset   = "UTF8"
       collation = "en_US.UTF8"
     }
@@ -153,8 +153,8 @@ module "db_science_platform" {
       password = random_password.ssotap.result
     },
     {
-      name     = "tap"
-      password = random_password.tap.result
+      name     = "obstap"
+      password = random_password.obstap.result
     }
   ]
 
@@ -203,7 +203,7 @@ module "service_accounts" {
   project_id    = var.project_id
   display_name  = "PostgreSQL client"
   description   = "Terraform-managed service account for PostgreSQL access"
-  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts", "ssotap", "tap"]
+  names         = ["gafaelfawr", "nublado", "times-square", "vo-cutouts", "ssotap", "obstap"]
   project_roles = ["${var.project_id}=>roles/cloudsql.client"]
 }
 
@@ -259,10 +259,10 @@ resource "google_service_account_iam_member" "ssotap_sa_wi" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[ssotap/ssotap]"
 }
 
-resource "google_service_account_iam_member" "tap_sa_wi" {
-  service_account_id = module.service_accounts.service_accounts_map["tap"].name
+resource "google_service_account_iam_member" "obstap_sa_wi" {
+  service_account_id = module.service_accounts.service_accounts_map["obstap"].name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.project_id}.svc.id.goog[tap/tap]"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[obstap/obstap]"
 }
 
 # The vo-cutouts service account must be granted the ability to generate

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -19,4 +19,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 12
+# Serial: 13


### PR DESCRIPTION
**Description**
We're creating a cloudSQL resource for the UWS database for the TAP service. Previously we did the same for the SSO TAP, which seems to be working as expected, so now doing the same for the main TAP.

**What envs are affected:**
- idfdev

**Other Notes**
We use "tap" as the database name. We then create a uws schema in that database in the application side and we can later add other schemas like (TAP_SCHEMA) to it.