### PR TITLE
DM-44606: Deploy recent changes to idfint

### DIFF
--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -19,4 +19,4 @@ db_maintenance_window_hour = 22
 backups_enabled            = true
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 7
+# Serial: 8


### PR DESCRIPTION
## Description

Deploy vo-cutouts permission changes and the new ssotap database on idfint. The vo-cutouts permission changes are required for the 2.0.0 release, which uses workload identity and no longer uses the Butler credentials.

This change also applies the changes in f1bd4fc89ec4d879c657e2d3def87eb4725131eb to use a better approach to configuring workload identity.

## Environments

- idfint

## Testing

Examined the Terraform plan, which looks correct. Due to the change in how workload identity is specified, there is a lot of resource churn since the old bindings have to be deleted and replaced with the new bindings.