### PR TITLE
DM-44606: Deploy recent changes to idfprod

### DIFF
--- a/environment/deployments/science-platform/env/production-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/production-cloudsql.tfvars
@@ -20,4 +20,4 @@ db_maintenance_window_hour = 22
 backups_enabled            = true
 
 # Increase this number to force Terraform to update the prod environment.
-# Serial: 4
+# Serial: 5


### PR DESCRIPTION
Trigger a Terraform run on the idfprod environment to update vo-cutout permissions, create new databases for tap and ssotap, and switch the way that IAM bindings are done in Terraform. This has already been tested on idfdev and idfint.