### PR TITLE
RSP Firestore Stable Label Fix

### DIFF
--- a/environment/deployments/science-platform/firestore/env/production.tfvars
+++ b/environment/deployments/science-platform/firestore/env/production.tfvars
@@ -1,6 +1,6 @@
 # Project
 environment                 = "stable"
-application_name            = "science-platform"
+application_name            = "science-platform-firestore"
 folder_id                   = "719717645081"
 budget_amount               = 1000
 budget_alert_spent_percents = [0.7, 0.8, 0.9, 1.0]


### PR DESCRIPTION
Fix label to be appended with firestore in name.   This updates it to reflect same naming as dev and int.