### PR TITLE
DM-46890: Add bucket metadata permissions for DP02

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -91,4 +91,4 @@ git_lfs_ro_dev_service_accounts = [
 ]
 
 # Increase this number to force Terraform to update the production environment.
-# Serial: 5
+# Serial: 6

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -255,15 +255,17 @@ resource "google_storage_bucket_iam_member" "data_curation_prod_rw_dp0" {
 }
 // RO storage access to DESC DC2 Run22i bucket
 resource "google_storage_bucket_iam_member" "data_curation_prod_ro_desc_dc2_run22i" {
-  bucket = "curation-us-central1-desc-dc2-run22i"
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  for_each = toset(["roles/storage.objectViewer", "roles/storage.legacyBucketReader"])
+  bucket   = "curation-us-central1-desc-dc2-run22i"
+  role     = each.value
+  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
 }
 // RO storage access to DESC DR6 bucket
 resource "google_storage_bucket_iam_member" "data_curation_prod_ro_desc_dr6" {
-  bucket = "butler-us-central1-dp01-desc-dr6"
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  for_each = toset(["roles/storage.objectViewer", "roles/storage.legacyBucketReader"])
+  bucket   = "butler-us-central1-dp01-desc-dr6"
+  role     = each.value
+  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
 }
 // RW storage access to the -dev Butler bucket
 resource "google_storage_bucket_iam_member" "data_curation_prod_rw_dp0_dev" {


### PR DESCRIPTION
An old version of the Butler used by some tutorial notebooks needs 'GetBucketLocation' permission to check for the existence of buckets at startup.  DM-46701 made more buckets part of the configuration that gets verified at startup, and these buckets don't have that configuration set.