### PR TITLE
DM-47492:  CloudSQL Int

### DIFF
--- a/.github/workflows/rsp-int-cloudsql-tf.yaml
+++ b/.github/workflows/rsp-int-cloudsql-tf.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.5
+        terraform_version: 1.9.5
 
      # Checks for proper formatting for terraform
     - name: Terraform Fmt

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -32,6 +32,7 @@ module "private-postgres" {
 
 # Butler Registry DP02
 module "db_butler_registry_dp02" {
+  count  = var.butler_registry_dp02_enable ? 1 : 0
   source = "../../../../modules/cloudsql/postgres-sql"
   authorized_networks = [
     {
@@ -263,10 +264,10 @@ module "service_accounts" {
   source  = "terraform-google-modules/service-accounts/google"
   version = ">= 4.0"
 
-  project_id    = var.project_id
-  display_name  = "PostgreSQL client"
-  description   = "Terraform-managed service account for PostgreSQL access"
-  names         = [
+  project_id   = var.project_id
+  display_name = "PostgreSQL client"
+  description  = "Terraform-managed service account for PostgreSQL access"
+  names = [
     "gafaelfawr",
     "nublado",
     "ssotap",

--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -120,8 +120,15 @@ variable "butler_registry_backups_point_in_time_recovery_enabled" {
 
 // Butler Registry DP02 Database variables
 
+variable "butler_registry_dp02_enable" {
+  type        = bool
+  description = "Conditionally enable Butler Registry DPO02"
+  default     = true
+}
+
 variable "butler_registry_dp02_db_name" {
   description = "The name of the SQL Database instance"
+  default     = "butler-registry-dp02"
 }
 
 variable "butler_registry_dp02_database_version" {
@@ -148,6 +155,7 @@ variable "butler_registry_dp02_database_flags" {
 variable "butler_registry_dp02_disk_size" {
   description = "The disk size for the instance in GB.  This value is ignored after initial provisioning with a terraform lifecycle policy in Google module.  This is needed because of auto storage increase is enabled."
   type        = number
+  default     = 100
 }
 
 variable "butler_registry_dp02_disk_type" {
@@ -159,6 +167,7 @@ variable "butler_registry_dp02_disk_type" {
 variable "butler_registry_dp02_edition" {
   description = "The edition of the Cloud SQL instance, can be ENTERPRISE or ENTERPRISE_PLUS."
   type        = string
+  default     = "ENTERPRISE"
 }
 
 
@@ -177,6 +186,7 @@ variable "butler_registry_dp02_ipv4_enabled" {
 variable "butler_registry_dp02_ssl_mode" {
   description = "Specify how SSL connection should be enforced in DB connections.  Options are ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY, and TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
   type        = string
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 }
 
 variable "butler_registry_dp02_database_tier" {

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -3,20 +3,26 @@ environment      = "int"
 application_name = "science-platform"
 project_id       = "science-platform-int-dc5d"
 
-# Butler database
-butler_db_name     = "butler-registry-int"
-butler_require_ssl = false
-butler_database_flags = [
+# Butler Registry Original Database
+butler_registry_db_name          = "butler-registry-int"
+butler_registry_database_version = "POSTGRES_13"
+butler_registry_require_ssl      = false
+butler_registry_database_flags = [
   { name = "temp_file_limit", value = 1049000000 },
   { name = "password_encryption", value = "scram-sha-256" }
 ]
-butler_database_version = "POSTGRES_13"
-butler_ipv4_enabled     = true
+butler_registry_ipv4_enabled                           = true
+butler_registry_db_maintenance_window_update_track     = "canary"
+butler_registry_backups_enabled                        = true
+butler_registry_backups_point_in_time_recovery_enabled = true
 
-# General database
-db_maintenance_window_day  = 2
-db_maintenance_window_hour = 22
-backups_enabled            = true
+# Butler Registry DP02
+butler_registry_dp02_enable = false
+
+# Science Platform Database
+science_platform_db_maintenance_window_day  = 2
+science_platform_db_maintenance_window_hour = 22
+science_platform_backups_enabled            = true
 
 # Increase this number to force Terraform to update the int environment.
 # Serial: 8


### PR DESCRIPTION
Changes to support terraform and google module upgrade.  Add conditionals and default values for Butler DP02 Registry so that registry is not created as part of this ticket and can be conditionally created per environment.  The terraform state was updated for the cutouts bucket so that the bucket is not destroyed.  The plan output shows that CloudSQL passwords are updated.  From testing in dev this is only the terraform state values and does not update CloudSQL passwords.  Note that passwords from terraform are not used.  CloudSQL users are created via terraform then the passwords are reset via the console.  Application connectivity from RSP to CloudSQL should be validated though after this change just in case.