### PR TITLE
Set up Postgres 16 DP02 butler SQL on data-int

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -66,6 +66,13 @@ module "db_butler_registry_dp02" {
   }
 }
 
+moved {
+  # The 'count' parameter to this module was added after it was already
+  # deployed to dev.
+  from = module.db_butler_registry_dp02
+  to = module.db_butler_registry_dp02[0]
+}
+
 resource "random_password" "gafaelfawr" {
   length  = 24
   numeric = true

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -73,6 +73,31 @@ moved {
   to = module.db_butler_registry_dp02[0]
 }
 
+resource "google_dns_managed_zone" "sql_private_zone" {
+  name        = "sql-private-zone"
+  dns_name    = "rsp-sql-${var.environment}.internal."
+  description = "DNS Zone containing domain names used to access internal databases."
+
+  visibility = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = data.google_compute_network.network.id
+    }
+  }
+}
+
+resource "google_dns_record_set" "dp02" {
+  count  = var.butler_registry_dp02_enable ? 1 : 0
+
+  managed_zone = google_dns_managed_zone.sql_private_zone.name
+  name         = "dp02.${google_dns_managed_zone.sql_private_zone.dns_name}"
+  type         = "A"
+  rrdatas      = [module.db_butler_registry_dp02[0].private_ip_address]
+  ttl          = 1800
+}
+
+
 resource "random_password" "gafaelfawr" {
   length  = 24
   numeric = true

--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -149,13 +149,16 @@ variable "butler_registry_dp02_database_flags" {
     name  = string
     value = string
   }))
-  default = []
+  default = [
+    { name = "max_connections", value = "400" },
+    { name = "password_encryption", value = "scram-sha-256" }
+  ]
 }
 
 variable "butler_registry_dp02_disk_size" {
   description = "The disk size for the instance in GB.  This value is ignored after initial provisioning with a terraform lifecycle policy in Google module.  This is needed because of auto storage increase is enabled."
   type        = number
-  default     = 100
+  default     = 700
 }
 
 variable "butler_registry_dp02_disk_type" {
@@ -174,7 +177,7 @@ variable "butler_registry_dp02_edition" {
 variable "butler_registry_dp02_require_ssl" {
   description = "True if the instance should require SSL/TLS for users connecting over IP. Note: SSL/TLS is needed to provide security when you connect to Cloud SQL using IP addresses. If you are connecting to your instance only by using the Cloud SQL Proxy or the Java Socket Library, you do not need to configure your instance to use SSL/TLS."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "butler_registry_dp02_ipv4_enabled" {

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -19,17 +19,7 @@ butler_registry_backups_point_in_time_recovery_enabled = true
 
 # Butler Registry DP02 Database
 butler_registry_dp02_db_name          = "butler-registry-dp02-dev"
-butler_registry_dp02_database_version = "POSTGRES_16"
 butler_registry_dp02_tier             = "db-custom-2-7680"
-butler_registry_dp02_require_ssl      = false
-butler_registry_dp02_disk_size        = 700
-butler_registry_dp02_database_flags = [
-  { name = "max_connections", value = "400" },
-  { name = "password_encryption", value = "scram-sha-256" }
-]
-butler_registry_dp02_edition                                = "ENTERPRISE"
-butler_registry_dp02_ipv4_enabled                           = false
-butler_registry_dp02_ssl_mode                               = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 butler_registry_dp02_db_maintenance_window_day              = 1
 butler_registry_dp02_db_maintenance_window_hour             = 23
 butler_registry_dp02_db_maintenance_window_update_track     = "stable"

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -33,4 +33,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 20
+# Serial: 21

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -31,4 +31,4 @@ science_platform_db_maintenance_window_hour = 22
 science_platform_backups_enabled            = true
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 8
+# Serial: 9

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -16,8 +16,14 @@ butler_registry_db_maintenance_window_update_track     = "canary"
 butler_registry_backups_enabled                        = true
 butler_registry_backups_point_in_time_recovery_enabled = true
 
-# Butler Registry DP02
-butler_registry_dp02_enable = false
+# Butler Registry DP02 Database
+butler_registry_dp02_db_name          = "butler-registry-dp02-int"
+butler_registry_dp02_tier             = "db-custom-2-7680"
+butler_registry_dp02_db_maintenance_window_day              = 2
+butler_registry_dp02_db_maintenance_window_hour             = 23
+butler_registry_dp02_db_maintenance_window_update_track     = "stable"
+butler_registry_dp02_backups_enabled                        = false
+butler_registry_dp02_backups_point_in_time_recovery_enabled = false
 
 # Science Platform Database
 science_platform_db_maintenance_window_day  = 2


### PR DESCRIPTION
Add Postgres 16 DB for the DP02 Butler to data-int.  Moved some configuration out of the tfvars file into the defaults so it can be shared between all the environments.

Also added domain names that can be used for referencing the databases from Phalanx configuration.

Added a 'moved' block to prevent terraform from destroying the `data-dev` DB.  The terraform code for this DB had changed since data-dev was last deployed.