### PR TITLE
DM-47492: RSP Project GCP Provider Versions Update

### DIFF
--- a/environment/deployments/science-platform/backend.tf
+++ b/environment/deployments/science-platform/backend.tf
@@ -6,7 +6,7 @@ terraform {
   backend "gcs" {
   }
   required_providers {
-    google      = "~> 3.51.0"
-    google-beta = "~> 3.51.0"
+    google      = ">= 5.0.0"
+    google-beta = ">= 5.0.0"
   }
 }

--- a/environment/deployments/science-platform/main.tf
+++ b/environment/deployments/science-platform/main.tf
@@ -167,7 +167,7 @@ module "nat" {
 
 module "service_account_cluster" {
   source     = "terraform-google-modules/service-accounts/google"
-  version    = "~> 2.0"
+  version    = "~> 4.4.3"
   project_id = module.project_factory.project_id
   prefix     = var.environment
   names      = ["cluster"]


### PR DESCRIPTION
Update RSP project GCP provider versions to support new terraform version.  I updated Terraform state to support these changes and posted the commands used in the ticket.