### PR TITLE
DM-45901: Make DNS zone name unique for each environment

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -74,7 +74,7 @@ moved {
 }
 
 resource "google_dns_managed_zone" "sql_private_zone" {
-  name        = "sql-private-zone"
+  name        = "sql-private-zone-${var.environment}"
   dns_name    = "rsp-sql-${var.environment}.internal."
   description = "DNS Zone containing domain names used to access internal databases."
 

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -33,4 +33,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 21
+# Serial: 22

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -31,4 +31,4 @@ science_platform_db_maintenance_window_hour = 22
 science_platform_backups_enabled            = true
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 9
+# Serial: 10


### PR DESCRIPTION
It turns out that Google Cloud will not allow two managed zones to have the same name even if they are in different projects.