### PR TITLE
DM-45901: Set up DP02 Butler DB on idfprod

### DIFF
--- a/environment/deployments/science-platform/env/production-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/production-cloudsql.tfvars
@@ -13,15 +13,20 @@ butler_registry_database_flags = [
   { name = "password_encryption", value = "scram-sha-256" },
   { name = "max_connections", value = 400 }
 ]
-
-# Butler Registry DP02
-butler_registry_dp02_enable = false
-
 butler_database_version = "POSTGRES_13"
 butler_registry_ipv4_enabled                           = false
 butler_registry_db_maintenance_window_update_track     = "canary"
 butler_registry_backups_enabled                        = true
 butler_registry_backups_point_in_time_recovery_enabled = true
+
+# Butler Registry DP02 Database
+butler_registry_dp02_db_name          = "butler-registry-dp02-prod"
+butler_registry_dp02_tier             = "db-custom-4-26624"
+butler_registry_dp02_db_maintenance_window_day              = 4
+butler_registry_dp02_db_maintenance_window_hour             = 22
+butler_registry_dp02_db_maintenance_window_update_track     = "stable"
+butler_registry_dp02_backups_enabled                        = true
+butler_registry_dp02_backups_point_in_time_recovery_enabled = true
 
 # Science Platform Database
 science_platform_db_maintenance_window_day  = 4


### PR DESCRIPTION
Enable the Postgres 16 Butler DB for DP02 on `science-platform-stable`.