### PR TITLE
DM-48589: Add Butler database for Data Preview 1 on idfdev

### DIFF
--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -234,6 +234,24 @@ variable "butler_registry_dp02_backups_point_in_time_recovery_enabled" {
   default     = true
 }
 
+variable "butler_registry_dp1_enabled" {
+  type        = bool
+  description = "Conditionally enable Butler Registry DPO02"
+  default     = false
+}
+
+variable "butler_registry_dp1_tier" {
+  description = "The tier for the master instance."
+  type        = string
+  default     = "db-custom-2-7680"
+}
+
+variable "butler_registry_dp1_backups_enabled" {
+  type        = bool
+  description = "True if backup configuration is enabled"
+  default     = false
+}
+
 // Science Platform Database variables
 
 variable "science_platform_database_version" {

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -26,6 +26,11 @@ butler_registry_dp02_db_maintenance_window_update_track     = "stable"
 butler_registry_dp02_backups_enabled                        = false
 butler_registry_dp02_backups_point_in_time_recovery_enabled = false
 
+# Butler Registry DP1 Database
+butler_registry_dp1_enabled           = true
+butler_registry_dp1_tier             = "db-custom-2-7680"
+butler_registry_dp1_backups_enabled  = false
+
 # Science Platform Database
 science_platform_db_maintenance_window_day          = 1
 science_platform_db_maintenance_window_hour         = 22
@@ -33,4 +38,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 22
+# Serial: 23


### PR DESCRIPTION
Add a Cloud SQL instance to use as the Butler Registry database for Data Preview 1 on the development environment.