### PR TITLE
DM-48589: Add GCS bucket for Data Preview 1

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -91,4 +91,4 @@ git_lfs_ro_dev_service_accounts = [
 ]
 
 # Increase this number to force Terraform to update the production environment.
-# Serial: 6
+# Serial: 7


### PR DESCRIPTION
Add a GCS bucket that will be used to hold the preliminary version of Data Preview 1, until infrastructure at USDF is available for hosting it.

The IAM accounts for this bucket are separate from the previous credentials -- unlike previous data previews, end users will not have direct S3 access to the bucket.