### PR TITLE
DM-48589: Enable Butler DP1 database for int and prod

### DIFF
--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -25,6 +25,11 @@ butler_registry_dp02_db_maintenance_window_update_track     = "stable"
 butler_registry_dp02_backups_enabled                        = false
 butler_registry_dp02_backups_point_in_time_recovery_enabled = false
 
+# Butler Registry DP1 Database
+butler_registry_dp1_enabled          = true
+butler_registry_dp1_tier             = "db-custom-2-7680"
+butler_registry_dp1_backups_enabled  = false
+
 # Science Platform Database
 science_platform_db_maintenance_window_day  = 2
 science_platform_db_maintenance_window_hour = 22

--- a/environment/deployments/science-platform/env/production-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/production-cloudsql.tfvars
@@ -28,6 +28,11 @@ butler_registry_dp02_db_maintenance_window_update_track     = "stable"
 butler_registry_dp02_backups_enabled                        = true
 butler_registry_dp02_backups_point_in_time_recovery_enabled = true
 
+# Butler Registry DP1 Database
+butler_registry_dp1_enabled          = true
+butler_registry_dp1_tier             = "db-custom-4-26624"
+butler_registry_dp1_backups_enabled  = true
+
 # Science Platform Database
 science_platform_db_maintenance_window_day  = 4
 science_platform_db_maintenance_window_hour = 22


### PR DESCRIPTION
Add a Cloud SQL instance to use for Data Preview 1 on the integration and production environments.