### PR TITLE
DM-49524: Give gafaelfawr-operator direct Cloud SQL access

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -385,10 +385,10 @@ resource "google_service_account_iam_member" "gafaelfawr_sa_wi" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]"
 }
 
-resource "google_service_account_iam_member" "gafaelfawr_schema_update_wi" {
+resource "google_service_account_iam_member" "gafaelfawr_operator_wi" {
   service_account_id = module.service_accounts.service_accounts_map["gafaelfawr"].name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-operator]"
 }
 
 resource "google_service_account_iam_member" "nublado_sa_wi" {

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -38,4 +38,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 23
+# Serial: 24


### PR DESCRIPTION
Previously, Cloud SQL access was done via a separate Cloud SQL Proxy pod that used the `gafaelfawr` service account, but we now want to use sidecar containers for the proxy uniformly. Grant direct Cloud SQL access to the separate `gafaelfawr-operator` Kubernetes service account.

Delete the permissions for `gafaelfawr-schema-update`, since the schema update `Job` now uses the regular `gafaelfawr` service account.