### PR TITLE
DM-49524: Change Gafaelfawr service accounts on Roundtable

### DIFF
--- a/environment/deployments/roundtable/cloudsql/main.tf
+++ b/environment/deployments/roundtable/cloudsql/main.tf
@@ -101,10 +101,10 @@ resource "google_service_account_iam_member" "gafaelfawr_sa_wi" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr]"
 }
 
-resource "google_service_account_iam_member" "gafaelfawr_schema_update_sa_wi" {
+resource "google_service_account_iam_member" "gafaelfawr_operator_sa_wi" {
   service_account_id = module.service_accounts.service_accounts_map["gafaelfawr"].name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-schema-update]"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[gafaelfawr/gafaelfawr-operator]"
 }
 
 resource "google_service_account_iam_member" "ook_sa_wi" {

--- a/environment/deployments/roundtable/env/dev-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/dev-cloudsql.tfvars
@@ -10,4 +10,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 6
+# Serial: 7

--- a/environment/deployments/roundtable/env/production-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/production-cloudsql.tfvars
@@ -9,4 +9,4 @@ db_maintenance_window_hour = 22
 backups_enabled            = true
 
 # Increase this number to force Terraform to update the prod environment.
-# Serial: 5
+# Serial: 6


### PR DESCRIPTION
Remove the workload identity binding for Gafaelfawr for the Kubernetes service account gafaelfawr-update-schema on Roundtable because it's no longer used. Add a binding for gafaelfawr-operator, since we're now going to use sidecar containers instead of a stand-alone Cloud SQL Proxy instance.