### PR TITLE
DM-49524: Apply Gafaelfawr changes to idfprod

### DIFF
--- a/environment/deployments/science-platform/env/production-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/production-cloudsql.tfvars
@@ -39,4 +39,4 @@ science_platform_db_maintenance_window_hour = 22
 science_platform_backups_enabled            = true
 
 # Increase this number to force Terraform to update the prod environment.
-# Serial: 6
+# Serial: 7


### PR DESCRIPTION
Bump the serial number to apply the Gafaelfawr service account mapping changes to idfprod. This will remove the mapping for the obsolete service account gafaelfawr-schema-update and grant Cloud SQL permissions to the gafaelfawr-operator service account.