### PR TITLE
DM-48684: Disable science-platform-dev legacy Butler database

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -1,6 +1,7 @@
 # Butler Registry Original.  Conditionally enabled with enable_butler_registry variable.  Remove after migration to Butler Registry DP02
 module "private-postgres" {
   source = "../../../../modules/cloudsql/postgres-private"
+  count  = var.enable_legacy_butler_registry ? 1 : 0
   authorized_networks = [
     {
       "name" : "sample-gcp-health-checkers-range",
@@ -28,6 +29,13 @@ module "private-postgres" {
     location                       = "us-central1"
     point_in_time_recovery_enabled = var.butler_registry_backups_point_in_time_recovery_enabled
   }
+}
+
+moved {
+  # The 'count' parameter to this module was added after it was already
+  # deployed to dev.
+  from = module.private-postgres
+  to = module.private-postgres[0]
 }
 
 # Butler Registry DP02

--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -234,6 +234,12 @@ variable "butler_registry_dp02_backups_point_in_time_recovery_enabled" {
   default     = true
 }
 
+variable "enable_legacy_butler_registry" {
+  type        = bool
+  description = "Enable Butler registry DB that was previously used for DP0.2"
+  default     = true
+}
+
 variable "butler_registry_dp1_enabled" {
   type        = bool
   description = "Conditionally enable Butler Registry DPO02"

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -16,6 +16,7 @@ butler_registry_db_maintenance_window_hour             = 23
 butler_registry_db_maintenance_window_update_track     = "canary"
 butler_registry_backups_enabled                        = true
 butler_registry_backups_point_in_time_recovery_enabled = true
+enable_legacy_butler_registry = false
 
 # Butler Registry DP02 Database
 butler_registry_dp02_db_name          = "butler-registry-dp02-dev"


### PR DESCRIPTION
This DB was never used.

Will fully remove the terraform associated with it in a later commit -- want to make sure it tears down cleanly before applying to `-int` and `-stable`.