### PR TITLE
DM-49696: Upgrade the idfdev science-platform CloudSQL

### DIFF
--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -263,7 +263,7 @@ variable "butler_registry_dp1_backups_enabled" {
 variable "science_platform_database_version" {
   description = "The database version to use for the Science Platform"
   type        = string
-  default     = "POSTGRES_13"
+  default     = "POSTGRES_14"
 }
 
 variable "science_platform_database_tier" {

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -39,4 +39,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 25
+# Serial: 26


### PR DESCRIPTION
Upgrade the CloudSQL database for the idfdev Science Platform to PostgreSQL 14 from PostgreSQL 13.