### PR TITLE
DM-48684: Move SQL private service access to top level

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -38,6 +38,20 @@ moved {
   to = module.private-postgres[0]
 }
 
+# Sets up a connection from the VPC to Google services, to allow the use of a
+# private IP.
+module "private-service-access" {
+  source = "../../../../modules/cloudsql/private_service_access"
+
+  project_id    = var.project_id
+  vpc_network   = var.network
+}
+
+moved {
+  from = module.private-postgres[0].module.private-service-access
+  to = module.private-service-access
+}
+
 # Butler Registry DP02
 module "db_butler_registry_dp02" {
   count  = var.butler_registry_dp02_enable ? 1 : 0

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -39,4 +39,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 24
+# Serial: 25

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -36,4 +36,4 @@ science_platform_db_maintenance_window_hour = 22
 science_platform_backups_enabled            = true
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 11
+# Serial: 12

--- a/modules/cloudsql/postgres-private/main.tf
+++ b/modules/cloudsql/postgres-private/main.tf
@@ -44,17 +44,6 @@ module "cloudsql-db" {
   }
 }
 
-module "private-service-access" {
-  source = "../private_service_access"
-
-  project_id    = var.project_id
-  vpc_network   = var.vpc_network
-  address       = var.address
-  prefix_length = var.prefix_length
-  ip_version    = var.ip_version
-  labels        = var.labels
-}
-
 module "service_accounts" {
   source        = "terraform-google-modules/service-accounts/google"
   version       = ">= 4.0"


### PR DESCRIPTION
The other science-platform databases are implicitly depending on private services access networking setup that was being created by the private-postgres module removed in DM-48684b.  Hoist the networking setup to the top level of the module so it isn't deleted.