### PR TITLE
DM-48684: Fix panda-dev deployment failure

### DIFF
--- a/environment/deployments/panda/cloudsql/main.tf
+++ b/environment/deployments/panda/cloudsql/main.tf
@@ -1,0 +1,14 @@
+# Sets up a connection from the VPC to Google services.  It's unclear what is
+# still using this, but terraform is refusing to delete it, claiming that it is
+# in use. Possibly something in the GKE setup is relying on it?
+module "private-service-access" {
+  source = "../../../../modules/cloudsql/private_service_access"
+
+  project_id    = var.project_id
+  vpc_network   = var.network
+}
+
+moved {
+  from = module.private-postgres.module.private-service-access
+  to = module.private-service-access
+}

--- a/environment/deployments/panda/cloudsql/variables.tf
+++ b/environment/deployments/panda/cloudsql/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  description = "The ID of the project in which resources will be provisioned."
+  type        = string
+}
+
+variable "network" {
+  description = "Name of the VPC"
+  type        = string
+}

--- a/environment/deployments/panda/env/dev-cloudsql.tfvars
+++ b/environment/deployments/panda/env/dev-cloudsql.tfvars
@@ -1,0 +1,5 @@
+project_id     = "panda-dev-1a74"
+network        = "panda-dev-vpc"
+
+# Increase this number to force Terraform to update the dev environment.
+# Serial: 10


### PR DESCRIPTION
Fix an issue where Private Service Access setup for the VPC could not be torn down during terraform deployment.