### PR TITLE
DM-44145: Prodromos (sentry config) terraform bucket and auth

### DIFF
--- a/.github/workflows/roundtable-prod-proj-tf.yaml
+++ b/.github/workflows/roundtable-prod-proj-tf.yaml
@@ -33,7 +33,7 @@ jobs:
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-    # gcloud setup     
+    # gcloud setup
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v2'
       with:
@@ -61,6 +61,12 @@ jobs:
     # Generates an execution plan for terraform
     - name: Terraform Plan
       id: plan
+      run: terraform plan -var-file=env/production.tfvars -no-color
+      continue-on-error: true
+
+    # Generates an execution plan for terraform
+    - name: Dan Fuchs Testing He Can Do Whatever He Pleases In A Branch
+      id: what-if-dfuchs-was-bad
       run: terraform plan -var-file=env/production.tfvars -no-color
       continue-on-error: true
 

--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -71,5 +71,7 @@ activate_apis = [
 
 vault_server_bucket_suffix = "vault-server-dev"
 
+prodromos_terraform_state_bucket_suffix = "prodromos-terraform-dev"
+
 # Increase this number to force Terraform to update the dev environment.
 # Serial: 12

--- a/environment/deployments/roundtable/env/production.tfvars
+++ b/environment/deployments/roundtable/env/production.tfvars
@@ -69,5 +69,6 @@ activate_apis = [
 
 vault_server_bucket_suffix = "vault-server"
 
+prodromos_terraform_state_bucket_suffix = "prodromos-terraform"
 # Increase this number to force Terraform to update the prod environment.
 # Serial: 9

--- a/environment/deployments/roundtable/outputs.tf
+++ b/environment/deployments/roundtable/outputs.tf
@@ -59,3 +59,14 @@ output "static_ip" {
   description = "Reserved static IP"
   value       = google_compute_address.static.*.address
 }
+
+// GitHub GCP auth federation
+output "github_workload_identity_provider" {
+  description = "ID of the Workload Identity Provider for GCP auth in GitHub workflows. This can be used as the `workload_identity_provider` value in `google-github-actions/auth` actions"
+  value       = google_iam_workload_identity_pool_provider.github.id
+}
+
+output "prodromos_github_service_account" {
+  description = "ID of the service account with powers to access Prodromos resources from GitHub workflows. This can be used as the `service_account` value in `google-github-actions/auth` actions."
+  value       = google_service_account.prodromos_github.email
+}

--- a/environment/deployments/roundtable/variables.tf
+++ b/environment/deployments/roundtable/variables.tf
@@ -184,3 +184,8 @@ variable "vault_server_bucket_suffix" {
   type        = string
   description = "Suffix for bucket used for Vault server storage"
 }
+
+variable "prodromos_terraform_state_bucket_suffix" {
+  type        = string
+  description = "Suffix for bucket used for Prodromos Terraform state"
+}


### PR DESCRIPTION
[Prodromos](https://github.com/lsst-sqre/prodromos) is a new project that contains terraform config for configuring Sentry for Phalanx projects.

These resources are provisioned to support that project:

* GCS bucket to keep the terraform state
* GCP authentication for workflows in the `lsst-sqre/prodromos` repo to read and write to that bucket
  * Workload Identity Pool in which to provision providers for federated auth in the `roundtable` project
  * Workload Identity Provider to federate auth from GitHub via OIDC
* Service account that has read/write access on the bucket
  * Mapped to a principal in the Workload Identity Pool with the `repository` attribute set to `lsst-sqre/prodromos`

This is based on:
* https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions
* https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token