### PR TITLE
DM-49696: Upgrade roundtable-dev Cloud SQL to PostgreSQL 15

### DIFF
--- a/environment/deployments/roundtable/cloudsql/variables.tf
+++ b/environment/deployments/roundtable/cloudsql/variables.tf
@@ -28,7 +28,7 @@ variable "database_tier" {
 variable "database_version" {
   description = "The database version to use for the general database"
   type        = string
-  default     = "POSTGRES_14"
+  default     = "POSTGRES_15"
 }
 
 variable "db_maintenance_window_day" {

--- a/environment/deployments/roundtable/env/dev-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/dev-cloudsql.tfvars
@@ -10,4 +10,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 8
+# Serial: 9


### PR DESCRIPTION
Continue the upgrades of our Cloud SQL databases by changing the default version for roundtable clusters to PostgreSQL 15 and triggering the update on roundtable-dev.