### PR TITLE
DM-49696: Upgrade idfdev Cloud SQL to PostgreSQL 16

### DIFF
--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -176,7 +176,7 @@ variable "butler_registry_dp1_backups_enabled" {
 variable "science_platform_database_version" {
   description = "The database version to use for the Science Platform"
   type        = string
-  default     = "POSTGRES_15"
+  default     = "POSTGRES_16"
 }
 
 variable "science_platform_database_tier" {

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -24,4 +24,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 27
+# Serial: 28


### PR DESCRIPTION
Upgrade the general-purpose science-platform Cloud SQL database for idfdev to PostgreSQL 16.