### PR TITLE
DM-49696: Upgrade Roundtable Cloud SQL to PostgreSQL 15

### DIFF
--- a/environment/deployments/roundtable/env/production-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/production-cloudsql.tfvars
@@ -8,9 +8,5 @@ db_maintenance_window_day  = 4
 db_maintenance_window_hour = 22
 backups_enabled            = true
 
-# Temporarily override the database version until we can get back in sync
-# with roundtable-dev.
-database_version = "POSTGRES_14"
-
 # Increase this number to force Terraform to update the prod environment.
 # Serial: 6


### PR DESCRIPTION
Remove the override for production Roundtable Cloud SQL and upgrade to PostgreSQL 15, the same as is currently running in roundtable-dev.