### PR TITLE
DM-49696: Upgrade roundtable-dev to PostgreSQL 16

### DIFF
--- a/environment/deployments/roundtable/cloudsql/variables.tf
+++ b/environment/deployments/roundtable/cloudsql/variables.tf
@@ -28,7 +28,7 @@ variable "database_tier" {
 variable "database_version" {
   description = "The database version to use for the general database"
   type        = string
-  default     = "POSTGRES_15"
+  default     = "POSTGRES_16"
 }
 
 variable "db_maintenance_window_day" {

--- a/environment/deployments/roundtable/env/dev-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/dev-cloudsql.tfvars
@@ -10,4 +10,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 9
+# Serial: 10


### PR DESCRIPTION
Upgrade the Cloud SQL version for roundtable to PostgreSQL 16 and apply Terraform to the roundtable-dev cluster.