### PR TITLE
DM-50677: Initial AlloyDB setup for Butler registry

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -101,6 +101,17 @@ module "db_butler_registry_dp1" {
   }
 }
 
+# AlloyDB Butler Registry for Data Preview 0.2 and Data Preview 1.
+# This is being explored as a more-scalable alternative to Cloud SQL.
+module "alloydb_butler_data_preview" {
+  source = "../../../../modules/alloydb"
+  count = var.butler_registry_alloydb_enabled ? 1 : 0
+
+  cluster_id = "butler-data-preview-${var.environment}"
+  location   = "us-central1"
+  network_id = data.google_compute_network.network.id
+}
+
 resource "google_dns_managed_zone" "sql_private_zone" {
   name        = "sql-private-zone-${var.environment}"
   dns_name    = "rsp-sql-${var.environment}.internal."

--- a/environment/deployments/science-platform/cloudsql/variables.tf
+++ b/environment/deployments/science-platform/cloudsql/variables.tf
@@ -171,6 +171,12 @@ variable "butler_registry_dp1_backups_enabled" {
   default     = false
 }
 
+variable "butler_registry_alloydb_enabled" {
+  type = bool
+  description = "True if an AlloyDB cluster will be created to use as the Butler Registry"
+  default = false
+}
+
 // Science Platform Database variables
 
 variable "science_platform_database_version" {

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -17,6 +17,9 @@ butler_registry_dp1_enabled          = true
 butler_registry_dp1_tier             = "db-custom-2-7680"
 butler_registry_dp1_backups_enabled  = false
 
+# Butler DP0.2/DP1 AlloyDB
+butler_registry_alloydb_enabled = true
+
 # Science Platform Database
 science_platform_db_maintenance_window_day  = 2
 science_platform_db_maintenance_window_hour = 22

--- a/modules/alloydb/main.tf
+++ b/modules/alloydb/main.tf
@@ -1,0 +1,40 @@
+resource "google_alloydb_cluster" "data_preview" {
+  cluster_id = var.cluster_id
+  database_version = "POSTGRES_16"
+  location   = "us-central1"
+  network_config {
+    network = var.network_id
+  }
+}
+
+resource "google_alloydb_instance" "data_preview_primary" {
+  cluster = google_alloydb_cluster.data_preview.name
+  instance_id = "${var.cluster_id}-primary"
+  instance_type = "PRIMARY"
+  machine_config {
+    machine_type = "n2-highmem-2"
+  }
+}
+
+resource "google_alloydb_instance" "data_preview_readpool" {
+  cluster = google_alloydb_cluster.data_preview.name
+  instance_id = "${var.cluster_id}-readpool"
+  instance_type = "READ_POOL"
+
+  machine_config {
+    machine_type = "n2-highmem-2"
+  }
+
+  read_pool_config {
+    node_count = 1
+  }
+
+  depends_on = [google_alloydb_instance.data_preview_primary]
+
+  lifecycle {
+    # Have Terraform ignore changes to the machine type and node count values.
+    # This allows the sizing of the read pool to be tweaked on the fly in the
+    # Google Cloud console.
+    ignore_changes = [machine_config[0].machine_type, read_pool_config[0].node_count]
+  }
+}

--- a/modules/alloydb/variables.tf
+++ b/modules/alloydb/variables.tf
@@ -1,0 +1,14 @@
+variable "cluster_id" {
+  description = "Name of the AlloyDB cluster"
+  type        = string
+}
+
+variable "network_id" {
+  description = "ID of the VPC that the database will exist in"
+  type        = string
+}
+
+variable "location" {
+  description = "Google data center location where the database will be created"
+  type        = string
+}


### PR DESCRIPTION
Set up an AlloyDB cluster to be used as the Butler registry for data previews, initially deployed to data-int.

This also captures an out-of-terraform configuration change to increase `max_connections` for the `science-platform` to 1000 from 100.