### PR TITLE
DM-50677: Tweak AlloyDB configuration

### DIFF
--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -147,6 +147,16 @@ resource "google_dns_record_set" "dp1" {
   ttl          = 1800
 }
 
+resource "google_dns_record_set" "alloydb_dp" {
+  count = var.butler_registry_alloydb_enabled ? 1 : 0
+
+  managed_zone = google_dns_managed_zone.sql_private_zone.name
+  name         = "alloydb-dp.${google_dns_managed_zone.sql_private_zone.dns_name}"
+  type         = "A"
+  rrdatas      = [module.alloydb_butler_data_preview[0].read_pool_private_ip]
+  ttl          = 1800
+}
+
 
 resource "random_password" "gafaelfawr" {
   length  = 24

--- a/modules/alloydb/main.tf
+++ b/modules/alloydb/main.tf
@@ -12,6 +12,11 @@ resource "google_alloydb_instance" "data_preview_primary" {
   cluster = google_alloydb_cluster.data_preview.name
   instance_id = "${var.cluster_id}-primary"
   instance_type = "PRIMARY"
+  # Only allocate a single node for the master, instead of two across
+  # multiple zones.
+  # End users will only be accessing the read pool, so we don't need
+  # the master to be highly available.
+  availability_type = "ZONAL"
   machine_config {
     machine_type = "n2-highmem-2"
   }

--- a/modules/alloydb/outputs.tf
+++ b/modules/alloydb/outputs.tf
@@ -1,0 +1,4 @@
+output "read_pool_private_ip" {
+  description = "IPv4 address of the read pool's private IP address (internal to the VPC)"
+  value       = google_alloydb_instance.data_preview_readpool.ip_address
+}


### PR DESCRIPTION
Add an internal domain name for the AlloyDB instance, and remove an unnecessary backup master node that will never be used.