### PR TITLE
DM-50677e: Set up Butler AlloyDB in production

### DIFF
--- a/environment/deployments/science-platform/env/production-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/production-cloudsql.tfvars
@@ -17,6 +17,9 @@ butler_registry_dp1_enabled          = true
 butler_registry_dp1_tier             = "db-custom-4-26624"
 butler_registry_dp1_backups_enabled  = true
 
+# Butler DP0.2/DP1 AlloyDB
+butler_registry_alloydb_enabled = true
+
 # Science Platform Database
 science_platform_db_maintenance_window_day  = 4
 science_platform_db_maintenance_window_hour = 22


### PR DESCRIPTION
Set up an AlloyDB instance for `idfprod`, which will initially be used for hosting DP1 and may eventually also contain DP0.2 and DP2.