### PR TITLE
DM-50315: Get failed deployment back to a consistent state

### DIFF
--- a/environment/deployments/science-platform/env/production.tfvars
+++ b/environment/deployments/science-platform/env/production.tfvars
@@ -32,11 +32,11 @@ fileshare_capacity = 24000
 
 # Filestore
 filestore_definitions = [
-  {
-    description = "Prod filestore for /project"
-    name = "project"
-    capacity = 8000
-  }
+  # {
+  #   description = "Prod filestore for /project"
+  #   name = "project"
+  #   capacity = 8000
+  # }
 ]
 
 # FIREWALL


### PR DESCRIPTION
The filestore on production failed to deploy due to a low quota, so remove it from the terraform for now.