### PR TITLE
Add EUPS Distributor Workload Identity

### DIFF
--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -74,4 +74,4 @@ vault_server_bucket_suffix = "vault-server-dev"
 prodromos_terraform_state_bucket_suffix = "prodromos-terraform-dev"
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 12
+# Serial: 13


### PR DESCRIPTION
Add service account and workload identity permissions for EUPS Distributor.  A service account named `eups-distributor` will need to be added to roundtable Kubernetes.