### PR TITLE
Enable FUSE for EUPS on Roundtable Prod

### DIFF
--- a/environment/deployments/roundtable/env/production-gke.tfvars
+++ b/environment/deployments/roundtable/env/production-gke.tfvars
@@ -92,4 +92,4 @@ node_pools_taints = {
 }
 
 # Increase this number to force Terraform to update the production environment.
-# Serial: 3
+# Serial: 4

--- a/environment/deployments/roundtable/env/production-gke.tfvars
+++ b/environment/deployments/roundtable/env/production-gke.tfvars
@@ -5,6 +5,7 @@ application_name        = "roundtable"
 # GKE
 master_ipv4_cidr_block = "172.30.0.0/28"
 gce_pd_csi_driver      = true
+gcs_fuse_csi_driver    = true
 network_policy         = true
 maintenance_start_time = "2021-08-20T00:00:00Z"
 maintenance_end_time   = "2021-08-20T12:00:00Z"


### PR DESCRIPTION
Bump serial to deploy FUSE to GKE.  Note that terraform apply takes ~50 minutes.  The node pools and applications stay up.  The time is spent updating the GKE control plane to install the FUSE CSI driver.  The deletion of the monitoring and logging service account is normal.  The access is built into GKE now so not needed.

The state was already fixed and validated with a manual terraform plan.