### PR TITLE
DM-47402 RSP GKE Dev Terraform Upgrade

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -66,4 +66,4 @@ node_pools_taints = {
 }
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 5
+# Serial: 6

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -46,6 +46,7 @@ module "gke" {
   maintenance_end_time   = var.maintenance_end_time
   maintenance_recurrence = var.maintenance_recurrence
   cluster_autoscaling    = var.cluster_autoscaling
+  enable_gcfs            = var.enable_gcfs
 
   # Labels
   cluster_resource_labels = {

--- a/environment/deployments/science-platform/gke/variables.tf
+++ b/environment/deployments/science-platform/gke/variables.tf
@@ -118,3 +118,9 @@ variable "node_pools_taints" {
     all = []
   }
 }
+
+variable "enable_gcfs" {
+  description = "Enable image streaming on cluster level"
+  type        = bool
+  default     = true
+}

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -44,6 +44,7 @@ module "gke" {
   gcs_fuse_csi_driver                = var.gcs_fuse_csi_driver
   cluster_telemetry_type             = var.cluster_telemetry_type
   default_max_pods_per_node          = var.default_max_pods_per_node
+  enable_gcfs                        = var.enable_gcfs 
 
   node_pools_labels = var.node_pools_labels
   node_pools_taints = var.node_pools_taints

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -202,6 +202,12 @@ variable "node_metadata" {
   type        = string
 }
 
+variable "enable_gcfs" {
+  description = "Enable image streaming on cluster level"
+  type        = bool
+  default     = false
+}
+
 # ----------------------------------------
 #  NODE POOL VALUES
 # ----------------------------------------


### PR DESCRIPTION
Bump serial after state cleaned up for terraform upgrade.  In the terraform plan the Filestore CSI driver will be disabled.  The Filestore CSI drive does not appear to be used since no PVs use the filestore CSI storage classes.  The Filestore CSI is not enabled on int or prod.  @athornton  - please confirm that the filestore CSI driver is ok to disable?  If not can add I can add it to terraform.

```
      ~ addons_config {
          ~ gcp_filestore_csi_driver_config {
              ~ enabled = true -> false
            }
```