### PR TITLE
DM-50932: Support for Google Clould Managed Service for Prometheus

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -1,6 +1,6 @@
 # Project
-environment             = "dev"
-application_name        = "science-platform"
+environment      = "dev"
+application_name = "science-platform"
 
 # GKE
 release_channel        = "RAPID"
@@ -9,13 +9,13 @@ gce_pd_csi_driver      = true
 maintenance_start_time = "2021-08-18T00:00:00Z"
 maintenance_end_time   = "2021-08-18T12:00:00Z"
 maintenance_recurrence = "FREQ=WEEKLY;BYDAY=WE"
-cluster_autoscaling    = {
-    enabled             = true
-    autoscaling_profile = "OPTIMIZE_UTILIZATION"
-    min_cpu_cores       = 0
-    max_cpu_cores       = 0
-    min_memory_gb       = 0
-    max_memory_gb       = 0
+cluster_autoscaling = {
+  enabled             = true
+  autoscaling_profile = "OPTIMIZE_UTILIZATION"
+  min_cpu_cores       = 0
+  max_cpu_cores       = 0
+  min_memory_gb       = 0
+  max_memory_gb       = 0
 }
 
 node_pools = [
@@ -58,12 +58,33 @@ node_pools = [
 node_pools_taints = {
   "user-lab-pool" = [
     {
-      key = "nublado.lsst.io/permitted"
-      value = "true"
+      key    = "nublado.lsst.io/permitted"
+      value  = "true"
       effect = "NO_EXECUTE"
     }
   ]
 }
+
+monitoring_enable_managed_prometheus = true
+monitoring_enabled_components = [
+  # Default
+  "SYSTEM_COMPONENTS",
+
+  # kube state metrics (gets us container last terminated reason, for
+  # monitoring OOM kills)
+  "DAEMONSET",
+  "DEPLOYMENT",
+  "HPA",
+  "POD",
+  "STATEFULSET",
+  "STORAGE",
+
+  # Gets us PVC disk usage metrics
+  "KUBELET",
+
+  # Gets us CPU throttling metrics
+  "CADVISOR"
+]
 
 # Increase this number to force Terraform to update the dev environment.
 # Serial: 6

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -48,6 +48,9 @@ module "gke" {
   cluster_autoscaling    = var.cluster_autoscaling
   enable_gcfs            = var.enable_gcfs
 
+  monitoring_enabled_components        = var.monitoring_enabled_components
+  monitoring_enable_managed_prometheus = var.monitoring_enable_managed_prometheus
+
   # Labels
   cluster_resource_labels = {
     environment      = var.environment

--- a/environment/deployments/science-platform/gke/variables.tf
+++ b/environment/deployments/science-platform/gke/variables.tf
@@ -124,3 +124,19 @@ variable "enable_gcfs" {
   type        = bool
   default     = true
 }
+
+variable "monitoring_enable_managed_prometheus" {
+  description = "Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "monitoring_enabled_components" {
+  description = <<-EOT
+    List of services to monitor: SYSTEM_COMPONENTS, APISERVER, SCHEDULER,
+    CONTROLLER_MANAGER, STORAGE, HPA, POD, DAEMONSET, DEPLOYMENT, STATEFULSET,
+    KUBELET, CADVISOR and DCGM. Empty list is default GKE configuration."
+  EOT
+  type        = list(string)
+  default     = []
+}

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -44,7 +44,10 @@ module "gke" {
   gcs_fuse_csi_driver                = var.gcs_fuse_csi_driver
   cluster_telemetry_type             = var.cluster_telemetry_type
   default_max_pods_per_node          = var.default_max_pods_per_node
-  enable_gcfs                        = var.enable_gcfs 
+  enable_gcfs                        = var.enable_gcfs
+
+  monitoring_enable_managed_prometheus = var.monitoring_enable_managed_prometheus
+  monitoring_enabled_components        = var.monitoring_enabled_components
 
   node_pools_labels = var.node_pools_labels
   node_pools_taints = var.node_pools_taints

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -272,3 +272,21 @@ variable "cluster_autoscaling" {
     max_memory_gb       = 0
   }
 }
+
+variable "monitoring_enable_managed_prometheus" {
+  description = "Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "monitoring_enabled_components" {
+  description = <<-EOT
+    List of services to monitor: SYSTEM_COMPONENTS, APISERVER, SCHEDULER,
+    CONTROLLER_MANAGER, STORAGE, HPA, POD, DAEMONSET, DEPLOYMENT, STATEFULSET,
+    KUBELET, CADVISOR and DCGM. Empty list is default GKE configuration."
+  EOT
+  type        = list(string)
+  default     = []
+
+}
+


### PR DESCRIPTION
* Modify the `gke` module to:
  * Provide options for enabling GCP's [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus)(MSP)
  * Allow enabling automatic collection of premium cluster metrics, like kube state metrics and kubelet metrics
* Enable MSP for the idfdev cluster
* Enable collection of kube state metrics (for OOM kill monitoring), kublet metrics (for PVC disk usage monitoring), and cadvisor metrics (for CPU throttling monitoring)