### PR TITLE
DM-47402 RSP GKE Int Terraform Provider Upgrade

### DIFF
--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -93,9 +93,5 @@ node_pools_taints = {
   
 }
 
-# TF State declared during pipeline
-# bucket = "lsst-terraform-state"
-# prefix = "qserv/int/gke"
-
 # Increase this number to force Terraform to update the int environment.
-# Serial: 6
+# Serial: 7

--- a/environment/deployments/science-platform/gke/main.tf
+++ b/environment/deployments/science-platform/gke/main.tf
@@ -33,21 +33,20 @@ module "gke" {
   source = "../../../../modules/gke"
 
   # Cluster
-  name                   = "${var.application_name}-${var.environment}"
-  project_id             = local.project_id
-  network                = var.network_name
-  subnetwork             = local.subnetwork
-  master_ipv4_cidr_block = var.master_ipv4_cidr_block
-  node_pools             = var.node_pools
-  release_channel        = var.release_channel
-  gce_pd_csi_driver      = var.gce_pd_csi_driver
-  network_policy         = var.network_policy
-  maintenance_start_time = var.maintenance_start_time
-  maintenance_end_time   = var.maintenance_end_time
-  maintenance_recurrence = var.maintenance_recurrence
-  cluster_autoscaling    = var.cluster_autoscaling
-  enable_gcfs            = var.enable_gcfs
-
+  name                                 = "${var.application_name}-${var.environment}"
+  project_id                           = local.project_id
+  network                              = var.network_name
+  subnetwork                           = local.subnetwork
+  master_ipv4_cidr_block               = var.master_ipv4_cidr_block
+  node_pools                           = var.node_pools
+  release_channel                      = var.release_channel
+  gce_pd_csi_driver                    = var.gce_pd_csi_driver
+  network_policy                       = var.network_policy
+  maintenance_start_time               = var.maintenance_start_time
+  maintenance_end_time                 = var.maintenance_end_time
+  maintenance_recurrence               = var.maintenance_recurrence
+  cluster_autoscaling                  = var.cluster_autoscaling
+  enable_gcfs                          = var.enable_gcfs
   monitoring_enabled_components        = var.monitoring_enabled_components
   monitoring_enable_managed_prometheus = var.monitoring_enable_managed_prometheus
 


### PR DESCRIPTION
Upgrade after terraform provider upgrade and state cleanup.  The account deletion is normal.  Temporarily added Security Admin to pipeline Terraform account to delete unused monitoring and logging service accounts.  Remember to remove role after deploying.