### PR TITLE
DM-50602: Grafana Postgres DB

### DIFF
--- a/environment/deployments/roundtable/cloudsql/main.tf
+++ b/environment/deployments/roundtable/cloudsql/main.tf
@@ -1,13 +1,20 @@
 resource "random_password" "gafaelfawr" {
   length  = 24
-  numeric  = true
+  numeric = true
+  upper   = true
+  special = false
+}
+
+resource "random_password" "grafana" {
+  length  = 24
+  numeric = true
   upper   = true
   special = false
 }
 
 resource "random_password" "ook" {
   length  = 24
-  numeric  = true
+  numeric = true
   upper   = true
   special = false
 }
@@ -53,6 +60,11 @@ module "db_roundtable" {
       collation = "en_US.UTF8"
     },
     {
+      name      = "grafana"
+      charset   = "UTF8"
+      collation = "en_US.UTF8"
+    },
+    {
       name      = "ook"
       charset   = "UTF8"
       collation = "en_US.UTF8"
@@ -61,13 +73,18 @@ module "db_roundtable" {
 
   additional_users = [
     {
-      name     = "gafaelfawr"
-      password = random_password.gafaelfawr.result
+      name            = "gafaelfawr"
+      password        = random_password.gafaelfawr.result
       random_password = false
     },
     {
-      name     = "ook"
-      password = random_password.ook.result
+      name            = "grafana"
+      password        = random_password.grafana.result
+      random_password = false
+    },
+    {
+      name            = "ook"
+      password        = random_password.ook.result
       random_password = false
     },
   ]

--- a/environment/deployments/roundtable/env/dev-cloudsql.tfvars
+++ b/environment/deployments/roundtable/env/dev-cloudsql.tfvars
@@ -10,4 +10,4 @@ db_maintenance_window_update_track = "canary"
 backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 10
+# Serial: 11

--- a/environment/deployments/science-platform/cloudsql/main.tf
+++ b/environment/deployments/science-platform/cloudsql/main.tf
@@ -3,17 +3,17 @@
 module "private-service-access" {
   source = "../../../../modules/cloudsql/private_service_access"
 
-  project_id    = var.project_id
-  vpc_network   = var.network
+  project_id  = var.project_id
+  vpc_network = var.network
 }
 
 moved {
   from = module.private-postgres
-  to = module.private-postgres[0]
+  to   = module.private-postgres[0]
 }
 moved {
   from = module.private-postgres[0].module.private-service-access
-  to = module.private-service-access
+  to   = module.private-service-access
 }
 
 # Butler Registry DP02
@@ -56,7 +56,7 @@ moved {
   # The 'count' parameter to this module was added after it was already
   # deployed to dev.
   from = module.db_butler_registry_dp02
-  to = module.db_butler_registry_dp02[0]
+  to   = module.db_butler_registry_dp02[0]
 }
 
 # Butler Registry for Data Preview 1
@@ -69,12 +69,12 @@ module "db_butler_registry_dp1" {
       "value" : "130.211.0.0/28"
     }
   ]
-  database_version                = "POSTGRES_16"
-  db_name                         = "butler-registry-dp1-${var.environment}"
-  tier                            = var.butler_registry_dp1_tier
-  database_flags                  = [
-      { name = "max_connections", value = "400" },
-      { name = "password_encryption", value = "scram-sha-256" }
+  database_version = "POSTGRES_16"
+  db_name          = "butler-registry-dp1-${var.environment}"
+  tier             = var.butler_registry_dp1_tier
+  database_flags = [
+    { name = "max_connections", value = "400" },
+    { name = "password_encryption", value = "scram-sha-256" }
   ]
   disk_size                       = 20
   enable_default_db               = false
@@ -105,7 +105,7 @@ module "db_butler_registry_dp1" {
 # This is being explored as a more-scalable alternative to Cloud SQL.
 module "alloydb_butler_data_preview" {
   source = "../../../../modules/alloydb"
-  count = var.butler_registry_alloydb_enabled ? 1 : 0
+  count  = var.butler_registry_alloydb_enabled ? 1 : 0
 
   cluster_id = "butler-data-preview-${var.environment}"
   location   = "us-central1"
@@ -128,7 +128,7 @@ resource "google_dns_managed_zone" "sql_private_zone" {
 }
 
 resource "google_dns_record_set" "dp02" {
-  count  = var.butler_registry_dp02_enable ? 1 : 0
+  count = var.butler_registry_dp02_enable ? 1 : 0
 
   managed_zone = google_dns_managed_zone.sql_private_zone.name
   name         = "dp02.${google_dns_managed_zone.sql_private_zone.dns_name}"
@@ -138,7 +138,7 @@ resource "google_dns_record_set" "dp02" {
 }
 
 resource "google_dns_record_set" "dp1" {
-  count  = var.butler_registry_dp1_enabled ? 1 : 0
+  count = var.butler_registry_dp1_enabled ? 1 : 0
 
   managed_zone = google_dns_managed_zone.sql_private_zone.name
   name         = "dp1.${google_dns_managed_zone.sql_private_zone.dns_name}"
@@ -159,6 +159,13 @@ resource "google_dns_record_set" "alloydb_dp" {
 
 
 resource "random_password" "gafaelfawr" {
+  length  = 24
+  numeric = true
+  upper   = true
+  special = false
+}
+
+resource "random_password" "grafana" {
   length  = 24
   numeric = true
   upper   = true
@@ -245,6 +252,11 @@ module "db_science_platform" {
       collation = "en_US.UTF8"
     },
     {
+      name      = "grafana"
+      charset   = "UTF8"
+      collation = "en_US.UTF8"
+    },
+    {
       name      = "nublado"
       charset   = "UTF8"
       collation = "en_US.UTF8"
@@ -280,6 +292,11 @@ module "db_science_platform" {
     {
       name            = "gafaelfawr"
       password        = random_password.gafaelfawr.result
+      random_password = false
+    },
+    {
+      name            = "grafana"
+      password        = random_password.grafana.result
       random_password = false
     },
     {

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -4,8 +4,8 @@ application_name = "science-platform"
 project_id       = "science-platform-dev-7696"
 
 # Butler Registry DP02 Database
-butler_registry_dp02_db_name          = "butler-registry-dp02-dev"
-butler_registry_dp02_tier             = "db-custom-2-7680"
+butler_registry_dp02_db_name                                = "butler-registry-dp02-dev"
+butler_registry_dp02_tier                                   = "db-custom-2-7680"
 butler_registry_dp02_db_maintenance_window_day              = 1
 butler_registry_dp02_db_maintenance_window_hour             = 23
 butler_registry_dp02_db_maintenance_window_update_track     = "stable"
@@ -13,9 +13,9 @@ butler_registry_dp02_backups_enabled                        = false
 butler_registry_dp02_backups_point_in_time_recovery_enabled = false
 
 # Butler Registry DP1 Database
-butler_registry_dp1_enabled           = true
-butler_registry_dp1_tier             = "db-custom-2-7680"
-butler_registry_dp1_backups_enabled  = false
+butler_registry_dp1_enabled         = true
+butler_registry_dp1_tier            = "db-custom-2-7680"
+butler_registry_dp1_backups_enabled = false
 
 # Science Platform Database
 science_platform_db_maintenance_window_day          = 1
@@ -24,4 +24,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 28
+# Serial: 29

--- a/environment/deployments/science-platform/env/integration-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/integration-cloudsql.tfvars
@@ -4,8 +4,8 @@ application_name = "science-platform"
 project_id       = "science-platform-int-dc5d"
 
 # Butler Registry DP02 Database
-butler_registry_dp02_db_name          = "butler-registry-dp02-int"
-butler_registry_dp02_tier             = "db-custom-2-7680"
+butler_registry_dp02_db_name                                = "butler-registry-dp02-int"
+butler_registry_dp02_tier                                   = "db-custom-2-7680"
 butler_registry_dp02_db_maintenance_window_day              = 2
 butler_registry_dp02_db_maintenance_window_hour             = 23
 butler_registry_dp02_db_maintenance_window_update_track     = "stable"
@@ -13,9 +13,9 @@ butler_registry_dp02_backups_enabled                        = false
 butler_registry_dp02_backups_point_in_time_recovery_enabled = false
 
 # Butler Registry DP1 Database
-butler_registry_dp1_enabled          = true
-butler_registry_dp1_tier             = "db-custom-2-7680"
-butler_registry_dp1_backups_enabled  = false
+butler_registry_dp1_enabled         = true
+butler_registry_dp1_tier            = "db-custom-2-7680"
+butler_registry_dp1_backups_enabled = false
 
 # Butler DP0.2/DP1 AlloyDB
 butler_registry_alloydb_enabled = true
@@ -26,4 +26,4 @@ science_platform_db_maintenance_window_hour = 22
 science_platform_backups_enabled            = true
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 17
+# Serial: 18


### PR DESCRIPTION
Grafana will be deployed in every Phalanx env.
It can use a SQLite DB, but:
* It doesn't work very well over networked storage
* It won't scale if Grafana gets a lot of usage, and we'll have to move to Postgres eventually anyway
* Alerting functionality works better with a Postgres instance

Eventually we want a separate database instance for Grafana so that we don't lose grafana when this database instance is under pressure (which is one situation where we will probably want it most), but let's just get it off the ground for DP1.