### PR TITLE
DM-51084: Give grafana SA monitoring.viewer (lower envs)

### DIFF
--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -74,4 +74,4 @@ vault_server_bucket_suffix = "vault-server-dev"
 prodromos_terraform_state_bucket_suffix = "prodromos-terraform-dev"
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 13
+# Serial: 14

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -172,6 +172,20 @@ resource "google_storage_bucket_iam_member" "vault_server_storage_transfer_sink_
   member = "serviceAccount:${data.google_storage_transfer_project_service_account.vault_backup_transfer_sa.email}"
 }
 
+// In-cluster Grafana access
+
+// The service account is created in the cloudsql config
+data "google_service_account" "grafana_service_account" {
+  account_id = "grafana"
+  project    = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "grafana_monitoring_viewer" {
+  service_account_id = data.google_service_account.grafana_service_account.name
+  role               = "roles/monitoring.viewer"
+  member             = data.google_service_account.grafana_service_account.member
+}
+
 // Resources for Vault Server storage backups
 
 resource "google_storage_transfer_job" "vault_server_storage_backup" {

--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -33,7 +33,7 @@ secondary_ranges = {
 
 # LEGACY filestore, to be removed once new volumes are in place and
 # data has been copied.
-fileshare_capacity = 2560  # Minimal
+fileshare_capacity = 2560 # Minimal
 
 # Filestore
 # 20250516: remove once data migrated to Netapp
@@ -88,70 +88,70 @@ nats = [{ name = "cloud-nat" }]
 # a storage pool/volume pair.
 #
 netapp_definitions = [
-  { name = "home"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
-    unix_permissions = "0775"
-    snapshot_directory = true
-    backups_enabled = true
-    has_root_access = true
-    access_type = "READ_WRITE"
+  { name                   = "home"
+    service_level          = "PREMIUM"
+    capacity_gib           = 2048
+    unix_permissions       = "0775"
+    snapshot_directory     = true
+    backups_enabled        = true
+    has_root_access        = true
+    access_type            = "READ_WRITE"
     default_user_quota_mib = 5000
     override_user_quotas = [
       {
-        username = "bot-mobu-user"
-        uid = 100001
+        username       = "bot-mobu-user"
+        uid            = 100001
         disk_limit_mib = 6000
       }
     ]
   },
-  { name = "rubin"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
-    unix_permissions = "1777"
-    snapshot_directory = true
-    backups_enabled = true
-    has_root_access = true
-    access_type = "READ_WRITE"
+  { name                   = "rubin"
+    service_level          = "PREMIUM"
+    capacity_gib           = 2048
+    unix_permissions       = "1777"
+    snapshot_directory     = true
+    backups_enabled        = true
+    has_root_access        = true
+    access_type            = "READ_WRITE"
     default_user_quota_mib = 5000
   },
-  { name = "firefly"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
+  { name             = "firefly"
+    service_level    = "PREMIUM"
+    capacity_gib     = 2048
     unix_permissions = "0755"
-    has_root_access = true
-    access_type = "READ_WRITE"
+    has_root_access  = true
+    access_type      = "READ_WRITE"
   },
-  { name = "deleted-weekly"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
+  { name             = "deleted-weekly"
+    service_level    = "PREMIUM"
+    capacity_gib     = 2048
     unix_permissions = "1777"
-    has_root_access = true
-    access_type = "READ_WRITE"
+    has_root_access  = true
+    access_type      = "READ_WRITE"
   },
   # 20250516: remove once data migrated to new volumes
-  { name = "project"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
-    unix_permissions = "1777"
-    snapshot_directory = true
-    backups_enabled = true
-    has_root_access = true
-    access_type = "READ_WRITE"
+  { name                   = "project"
+    service_level          = "PREMIUM"
+    capacity_gib           = 2048
+    unix_permissions       = "1777"
+    snapshot_directory     = true
+    backups_enabled        = true
+    has_root_access        = true
+    access_type            = "READ_WRITE"
     default_user_quota_mib = 5000
   },
   # 20250516: remove once data migrated to new volumes
-  { name = "scratch"
-    service_level = "PREMIUM"
-    capacity_gib = 2049
-    unix_permissions = "1777"
-    has_root_access = true
-    access_type = "READ_WRITE"
+  { name                   = "scratch"
+    service_level          = "PREMIUM"
+    capacity_gib           = 2049
+    unix_permissions       = "1777"
+    has_root_access        = true
+    access_type            = "READ_WRITE"
     default_user_quota_mib = 5000
     override_user_quotas = [
       {
-        username = "adam"
-        uid = 3000001
+        username       = "adam"
+        uid            = 3000001
         disk_limit_mib = 30000
       }
     ]
@@ -179,4 +179,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 41
+# Serial: 42

--- a/environment/deployments/science-platform/env/integration.tfvars
+++ b/environment/deployments/science-platform/env/integration.tfvars
@@ -86,43 +86,43 @@ num_static_ips = 1
 # a storage pool/volume pair.
 #
 netapp_definitions = [
-  { name = "home"
-    service_level = "PREMIUM"
-    capacity_gib = 5000
-    unix_permissions = "0775"
-    snapshot_directory = true
-    backups_enabled = true
-    has_root_access = true
-    access_type = "READ_WRITE"
+  { name                   = "home"
+    service_level          = "PREMIUM"
+    capacity_gib           = 5000
+    unix_permissions       = "0775"
+    snapshot_directory     = true
+    backups_enabled        = true
+    has_root_access        = true
+    access_type            = "READ_WRITE"
     default_user_quota_mib = 35000
   },
-  { name = "rubin"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
-    unix_permissions = "1777"
-    snapshot_directory = false
-    backups_enabled = true
-    has_root_access = true
-    access_type = "READ_WRITE"
+  { name                   = "rubin"
+    service_level          = "PREMIUM"
+    capacity_gib           = 2048
+    unix_permissions       = "1777"
+    snapshot_directory     = false
+    backups_enabled        = true
+    has_root_access        = true
+    access_type            = "READ_WRITE"
     default_user_quota_mib = 10000
   },
-  { name = "firefly"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
-    unix_permissions = "0755"
+  { name               = "firefly"
+    service_level      = "PREMIUM"
+    capacity_gib       = 2048
+    unix_permissions   = "0755"
     snapshot_directory = false
-    backups_enabled = false
-    has_root_access = true
-    access_type = "READ_WRITE"
+    backups_enabled    = false
+    has_root_access    = true
+    access_type        = "READ_WRITE"
   },
-  { name = "delete-weekly"
-    service_level = "PREMIUM"
-    capacity_gib = 2048
-    unix_permissions = "1777"
+  { name               = "delete-weekly"
+    service_level      = "PREMIUM"
+    capacity_gib       = 2048
+    unix_permissions   = "1777"
     snapshot_directory = false
-    backups_enabled = false
-    has_root_access = true
-    access_type = "READ_WRITE"
+    backups_enabled    = false
+    has_root_access    = true
+    access_type        = "READ_WRITE"
   },
 ]
 
@@ -146,4 +146,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 16
+# Serial: 17

--- a/environment/deployments/science-platform/main.tf
+++ b/environment/deployments/science-platform/main.tf
@@ -103,6 +103,20 @@ resource "google_service_account_iam_member" "sqlproxy_butler_int_sa" {
   member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[sqlproxy-cross-project/sqlproxy-butler-int]"
 }
 
+// In-cluster Grafana access
+
+// The service account is created in the cloudsql config
+data "google_service_account" "grafana_service_account" {
+  account_id = "grafana"
+  project    = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "grafana_monitoring_viewer" {
+  service_account_id = data.google_service_account.grafana_service_account.name
+  role               = "roles/monitoring.viewer"
+  member             = data.google_service_account.grafana_service_account.member
+}
+
 // Reserve a static ip for Cloud NAT
 resource "google_compute_address" "static" {
   count        = var.num_static_ips


### PR DESCRIPTION
This will let us query our Google Cloud Monitoring metrics from our in-cluster Grafana instance.

It's possible that the `member` attribute has to be the k8s service account identifier variety, but I don't think so. I'll find out after this is applied :)