### PR TITLE
DM-51084: Give grafana SA monitoring.viewer (prod envs)

### DIFF
--- a/environment/deployments/roundtable/env/production.tfvars
+++ b/environment/deployments/roundtable/env/production.tfvars
@@ -71,4 +71,4 @@ vault_server_bucket_suffix = "vault-server"
 
 prodromos_terraform_state_bucket_suffix = "prodromos-terraform"
 # Increase this number to force Terraform to update the prod environment.
-# Serial: 10
+# Serial: 11

--- a/environment/deployments/science-platform/env/production.tfvars
+++ b/environment/deployments/science-platform/env/production.tfvars
@@ -34,8 +34,8 @@ fileshare_capacity = 24000
 filestore_definitions = [
   {
     description = "Prod filestore for /project"
-    name = "project"
-    capacity = 8000
+    name        = "project"
+    capacity    = 8000
   }
 ]
 
@@ -92,4 +92,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the production environment.
-# Serial: 4
+# Serial: 5


### PR DESCRIPTION
# DO NOT MERGE UNTIL PATCH

This will let us query our Google Cloud Monitoring metrics from our in-cluster Grafana instance.

It will also apply anything else that happens to ride along in the time between now and when we merge it...