### PR TITLE
DM-51084: Fix grafana service account permissions

### DIFF
--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -74,4 +74,4 @@ vault_server_bucket_suffix = "vault-server-dev"
 prodromos_terraform_state_bucket_suffix = "prodromos-terraform-dev"
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 14
+# Serial: 15

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -180,10 +180,10 @@ data "google_service_account" "grafana_service_account" {
   project    = module.project_factory.project_id
 }
 
-resource "google_service_account_iam_member" "grafana_monitoring_viewer" {
-  service_account_id = data.google_service_account.grafana_service_account.name
-  role               = "roles/monitoring.viewer"
-  member             = data.google_service_account.grafana_service_account.member
+resource "google_project_iam_member" "grafana_monitoring_viewer" {
+  project = module.project_factory.project_id
+  role    = "roles/monitoring.viewer"
+  member  = data.google_service_account.grafana_service_account.member
 }
 
 // Resources for Vault Server storage backups

--- a/environment/deployments/science-platform/env/integration.tfvars
+++ b/environment/deployments/science-platform/env/integration.tfvars
@@ -146,4 +146,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 17
+# Serial: 18

--- a/environment/deployments/science-platform/main.tf
+++ b/environment/deployments/science-platform/main.tf
@@ -111,10 +111,10 @@ data "google_service_account" "grafana_service_account" {
   project    = module.project_factory.project_id
 }
 
-resource "google_service_account_iam_member" "grafana_monitoring_viewer" {
-  service_account_id = data.google_service_account.grafana_service_account.name
-  role               = "roles/monitoring.viewer"
-  member             = data.google_service_account.grafana_service_account.member
+resource "google_project_iam_member" "grafana_monitoring_viewer" {
+  project = module.project_factory.project_id
+  role    = "roles/monitoring.viewer"
+  member  = data.google_service_account.grafana_service_account.member
 }
 
 // Reserve a static ip for Cloud NAT


### PR DESCRIPTION
[google_service_account_iam_*](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_iam) is to "allow the members to run operations as or modify the service account" [google_project_iam_*](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#google_project_iam_member) is to "configure permissions for a service account on other GCP resources" which is what we want here.