### PR TITLE
DM-50932: Don't collect pod metrics with managed kube-state-metrics

### DIFF
--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -70,14 +70,17 @@ monitoring_enabled_components = [
   # Default
   "SYSTEM_COMPONENTS",
 
-  # kube state metrics (gets us container last terminated reason, for
-  # monitoring OOM kills)
-  "DAEMONSET",
-  "DEPLOYMENT",
-  "HPA",
-  "POD",
-  "STATEFULSET",
-  "STORAGE",
+  # Don't include kube-state-metrics, because the managed kube-state-metrics
+  # doesn't provide kube_pod_container_status_last_terminated_reason, and
+  # kube_pod_container_status_restarts_total, which are essential to alerting
+  # on OOM kills. Phalanx installations can run their own kube-state-metrics
+  # with these and other metrics, configured in the google-cloud-observability
+  # app:
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/kube-state-metrics
+  #
+  # Google recommends not using the managed kube-state-metrics at all if you're
+  # going to run your own:
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/kube-state-metrics#requirements
 
   # Gets us PVC disk usage metrics
   "KUBELET",


### PR DESCRIPTION
The managed collection of pod metrics [doesn't include kube_pod_container_status_last_terminated_reason or kube_pod_container_status_restarts_total](https://issuetracker.google.com/issues/418169221), which is the best way to alert on OOM kills by pod and container name. So, we have to run our own kube-state-metrics exporter to provide pod metrics. This PR disables the managed kube-state-metrics collectors we won't get double metrics when we're running our own kube-state-metrics exporter.
