### PR TITLE
DM-50932: Service account for in-cluster access to google cloud monitoring (lower envs)

### DIFF
--- a/environment/deployments/roundtable/env/dev.tfvars
+++ b/environment/deployments/roundtable/env/dev.tfvars
@@ -74,4 +74,4 @@ vault_server_bucket_suffix = "vault-server-dev"
 prodromos_terraform_state_bucket_suffix = "prodromos-terraform-dev"
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 15
+# Serial: 16

--- a/environment/deployments/roundtable/main.tf
+++ b/environment/deployments/roundtable/main.tf
@@ -186,6 +186,36 @@ resource "google_project_iam_member" "grafana_monitoring_viewer" {
   member  = data.google_service_account.grafana_service_account.member
 }
 
+// A separate service account is needed for google cloud monitoring access
+// through the built-in Prometheus plugin because it doesn't speak oauth2 and
+// we need a separate process to periodically auth to google and update a JWT
+// in grafana via the grafana API:
+//
+// https://cloud.google.com/stackdriver/docs/managed-prometheus/query#ui-grafana
+resource "google_service_account" "grafana_datasource_syncer" {
+  account_id   = "grafana-datasource-syncer"
+  display_name = "Created by Terraform"
+  project      = module.project_factory.project_id
+}
+
+resource "google_service_account_iam_member" "grafana_datasource_syncer" {
+  service_account_id = google_service_account.grafana_datasource_syncer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${module.project_factory.project_id}.svc.id.goog[google-cloud-observability/grafana-datasource-syncer]"
+}
+
+resource "google_project_iam_member" "grafana_datasource_syncer_monitoring_viewer" {
+  project = module.project_factory.project_id
+  role    = "roles/monitoring.viewer"
+  member  = google_service_account.grafana_datasource_syncer.member
+}
+
+resource "google_project_iam_member" "grafana_datasource_syncer_service_account_token_creator" {
+  project = module.project_factory.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = google_service_account.grafana_datasource_syncer.member
+}
+
 // Resources for Vault Server storage backups
 
 resource "google_storage_transfer_job" "vault_server_storage_backup" {

--- a/environment/deployments/science-platform/env/dev.tfvars
+++ b/environment/deployments/science-platform/env/dev.tfvars
@@ -161,4 +161,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 43
+# Serial: 44

--- a/environment/deployments/science-platform/env/integration.tfvars
+++ b/environment/deployments/science-platform/env/integration.tfvars
@@ -146,4 +146,4 @@ activate_apis = [
 ]
 
 # Increase this number to force Terraform to update the int environment.
-# Serial: 18
+# Serial: 19


### PR DESCRIPTION
Create a service account with the appropriate powers to enable the built-in Grafana Prometheus plugin to query the [Google Cloud Managed Service For Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) via the [datasource-syncer](https://github.com/GoogleCloudPlatform/prometheus-engine/tree/main/cmd/datasource-syncer) as described in the [these Google docs](https://cloud.google.com/stackdriver/docs/managed-prometheus/query#ui-grafana)

How is this different from https://github.com/lsst/idf_deploy/pull/641, you may ask? There, we gave the *grafana federated service account access* to Google monitoring APIs from inside the cluster. This would allow Grafana to auth to Google to pull data via the [Google Cloud Monitoring Data Source](https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/) via oauth2. The built-in Prometheus data source does not have the ability to auth via oauth2, so we need _another_ service account to run the datasource-syncer to refresh tokens and the grafana config on a schedule.