### PR TITLE
DM-51280: Add a bucket for DP1 HiPS

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -91,4 +91,4 @@ git_lfs_ro_dev_service_accounts = [
 ]
 
 # Increase this number to force Terraform to update the production environment.
-# Serial: 8
+# Serial: 9

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -150,24 +150,32 @@ module "storage_bucket_4" {
   project_id    = module.project_factory.project_id
   storage_class = "REGIONAL"
   location      = "us-central1"
-  suffix_name   = ["dp02-hips"]
+  suffix_name   = ["dp02-hips", "dp1-hips"]
   prefix_name   = "static-us-central1"
   versioning = {
     dp02-hips = false
+    dp1-hips = false
   }
   force_destroy = {
     dp02-hips = false
+    dp1-hips = false
   }
   labels = {
     environment = var.environment
     application = "hips"
   }
 }
-// RO storage access to HiPS VISTA bucket
-resource "google_storage_bucket_iam_binding" "dp02-hips-bucket-ro-iam-binding" {
-  bucket  = module.storage_bucket_4.name
+// RO storage access to HiPS buckets
+resource "google_storage_bucket_iam_binding" "dp-hips-bucket-ro-iam-binding" {
+  for_each = toset(module.storage_bucket_4.names_list)
+  bucket  = each.key
   role    = "roles/storage.objectViewer"
   members = var.hips_service_accounts
+}
+
+moved {
+  from = google_storage_bucket_iam_binding.dp02-hips-bucket-ro-iam-binding
+  to = google_storage_bucket_iam_binding.dp-hips-bucket-ro-iam-binding["static-us-central1-dp02-hips"]
 }
 
 // Git LFS Storage Bucket (Prod)


### PR DESCRIPTION
Set up a bucket to store the Data Preview 1 HiPS maps, with access granted to the crawlspace service account.