### PR TITLE
DM-51374: Disable end-user Butler service account

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -91,4 +91,4 @@ git_lfs_ro_dev_service_accounts = [
 ]
 
 # Increase this number to force Terraform to update the production environment.
-# Serial: 9
+# Serial: 10

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -242,62 +242,63 @@ resource "google_storage_bucket_iam_binding" "git-lfs-bucket-dev-rw-iam-binding"
   members = var.git_lfs_rw_dev_service_accounts
 }
 
-#---------------------------------------------------------------
-// Data Curation Prod
-#---------------------------------------------------------------
-module "data_curation_prod_accounts" {
-  source = "../../../modules/service_accounts/"
-
-  project_id   = "data-curation-prod-fbdb"
-  prefix       = "butler-gcs"
-  names        = var.data_curation_prod_names
+# This account was formerly used by end users for direct butler
+# access.  Users should no longer provided with this access,
+# but for the moment this is disabled instead of deleted
+# to confirm there are no surprises.
+resource "google_service_account" "legacy_butler_service_account" {
+  account_id = "butler-gcs-butler-gcs-data-sa"
   display_name = "Butler GCS Service account for Data Curation Prod"
   description  = "Butler GCS access service account managed by Terraform"
-
-  project_roles = [
-  ]
+  disabled = true
 }
+
+moved {
+  from=module.data_curation_prod_accounts.module.service_accounts.something
+  to=google_service_account.legacy_butler_service_account
+}
+
 // RW storage access to DP 0.1 bucket for Butler
 resource "google_storage_bucket_iam_member" "data_curation_prod_rw_dp0" {
   for_each = toset(["roles/storage.objectAdmin", "roles/storage.legacyBucketReader"])
   bucket   = "butler-us-central1-dp01"
   role     = each.value
-  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  member   = "serviceAccount:${google_service_account.legacy_butler_service_account.email}"
 }
 // RW storage access to the -dev Butler bucket
 resource "google_storage_bucket_iam_member" "data_curation_prod_rw_dp0_dev" {
   for_each = toset(["roles/storage.objectAdmin", "roles/storage.legacyBucketReader"])
   bucket   = "butler-us-central1-dp01-dev"
   role     = each.value
-  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  member   = "serviceAccount:${google_service_account.legacy_butler_service_account.email}"
 }
 // RW storage access to the -int Butler bucket
 resource "google_storage_bucket_iam_member" "data_curation_prod_rw_dp0_int" {
   for_each = toset(["roles/storage.objectAdmin", "roles/storage.legacyBucketReader"])
   bucket   = "butler-us-central1-dp01-int"
   role     = each.value
-  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  member   = "serviceAccount:${google_service_account.legacy_butler_service_account.email}"
 }
 // RW storage access to repo-locations Butler bucket 
 resource "google_storage_bucket_iam_member" "data_curation_prod_rw_repo_locations" {
   for_each = toset(["roles/storage.objectAdmin", "roles/storage.legacyBucketReader"])
   bucket   = "butler-us-central1-repo-locations"
   role     = each.value
-  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  member   = "serviceAccount:${google_service_account.legacy_butler_service_account.email}"
 }
 // RW storage access to DP 0.2 bucket for Butler
 resource "google_storage_bucket_iam_member" "data_curation_prod_rw_dp02_user" {
   for_each = toset(["roles/storage.objectAdmin", "roles/storage.legacyBucketReader"])
   bucket   = "butler-us-central1-dp02-user"
   role     = each.value
-  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  member   = "serviceAccount:${google_service_account.legacy_butler_service_account.email}"
 }
 // RW storage access to DP 0.2 HiPS bucket for Butler (temporary)
 resource "google_storage_bucket_iam_member" "data_curation_prod_rw_dp02_hips" {
   for_each = toset(["roles/storage.objectAdmin", "roles/storage.legacyBucketReader"])
   bucket   = "static-us-central1-dp02-hips"
   role     = each.value
-  member   = "serviceAccount:${module.data_curation_prod_accounts.email}"
+  member   = "serviceAccount:${google_service_account.legacy_butler_service_account.email}"
 }
 
 

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -254,8 +254,8 @@ resource "google_service_account" "legacy_butler_service_account" {
 }
 
 moved {
-  from=module.data_curation_prod_accounts.module.service_accounts.something
-  to=google_service_account.legacy_butler_service_account
+  from = module.data_curation_prod_accounts.module.service_accounts.google_service_account.service_accounts["butler-gcs-data-sa"]
+  to = google_service_account.legacy_butler_service_account
 }
 
 // RW storage access to DP 0.1 bucket for Butler
@@ -320,6 +320,13 @@ module "butler_server_account" {
 resource "google_storage_bucket_iam_member" "data_curation_prod_ro_dp1" {
   for_each = toset(["roles/storage.objectViewer", "roles/storage.legacyBucketReader"])
   bucket   = "butler-us-central1-dp1"
+  role     = each.value
+  member   = "serviceAccount:${module.butler_server_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "data_curation_prod_ro_dp02_user" {
+  for_each = toset(["roles/storage.objectViewer", "roles/storage.legacyBucketReader"])
+  bucket   = "butler-us-central1-dp02-user"
   role     = each.value
   member   = "serviceAccount:${module.butler_server_account.email}"
 }


### PR DESCRIPTION
Disable a Butler service account that is no longer used, and which has had its credentials provided to end users.

Give a private Butler server service account access to the dp02-users bucket, which it was formerly using the other account to access.