### PR TITLE
DM-51851: Enable SCHEDULER metrics in dev clusters

### DIFF
--- a/environment/deployments/roundtable/env/dev-gke.tfvars
+++ b/environment/deployments/roundtable/env/dev-gke.tfvars
@@ -52,7 +52,10 @@ monitoring_enabled_components = [
   "KUBELET",
 
   # Gets us CPU throttling metrics
-  "CADVISOR"
+  "CADVISOR",
+
+  # Gets us sum of requests/limits per node
+  "SCHEDULER",
 ]
 
 # Increase this number to force Terraform to update the dev environment.

--- a/environment/deployments/science-platform/env/dev-gke.tfvars
+++ b/environment/deployments/science-platform/env/dev-gke.tfvars
@@ -86,7 +86,10 @@ monitoring_enabled_components = [
   "KUBELET",
 
   # Gets us CPU throttling metrics
-  "CADVISOR"
+  "CADVISOR",
+
+  # Gets us sum of requests/limits per node
+  "SCHEDULER",
 ]
 
 # Increase this number to force Terraform to update the dev environment.

--- a/environment/deployments/science-platform/env/integration-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-gke.tfvars
@@ -114,7 +114,10 @@ monitoring_enabled_components = [
   "KUBELET",
 
   # Gets us CPU throttling metrics
-  "CADVISOR"
+  "CADVISOR",
+
+  # Gets us sum of requests/limits per node
+  "SCHEDULER",
 ]
 
 # Increase this number to force Terraform to update the int environment.


### PR DESCRIPTION
This gets us `kube_pod_resources_limit` and `kube_pod_resource_request`, which let us aggregate pod resource limits and request by node, which will help us estimate how much $$ Autopilot will save us.

https://cloud.google.com/kubernetes-engine/docs/how-to/control-plane-metrics