### PR TITLE
DM-54620: `roundtable-dev`: reorder monitoring components

### DIFF
--- a/environment/deployments/roundtable/env/dev-new-gke.tfvars
+++ b/environment/deployments/roundtable/env/dev-new-gke.tfvars
@@ -54,18 +54,18 @@ monitoring_enabled_components = [
   # going to run your own:
   # https://cloud.google.com/kubernetes-engine/docs/how-to/kube-state-metrics#requirements
 
-  # Gets us PVC disk usage metrics
-  "KUBELET",
-
-  # Gets us CPU throttling metrics
-  "CADVISOR",
+  # Gets us Kubernetes API server metrics, to help diagnose errors in our
+  # controllers
+  "APISERVER",
 
   # Gets us sum of requests/limits per node
   "SCHEDULER",
 
-  # Gets us Kubernetes API server metrics, to help diagnose errors in our
-  # controllers
-  "APISERVER",
+  # Gets us CPU throttling metrics
+  "CADVISOR",
+
+  # Gets us PVC disk usage metrics
+  "KUBELET",
 ]
 
 gke_backup_agent_config = true


### PR DESCRIPTION
They need to be in a certain order or else there is dirt. I'm not sure if this is deterministic or not. This change gets rid of the dirt for now...

https://github.com/lsst/idf_deploy/actions/runs/24225026695/job/70724350295

```
  # module.gke.module.gke.google_container_cluster.primary will be updated in-place
  ~ resource "google_container_cluster" "primary" {
        id                                       = "projects/roundtable-dev-abe2/locations/us-central1/clusters/roundtable-dev-2"
        name                                     = "roundtable-dev-2"
        # (39 unchanged attributes hidden)

      ~ monitoring_config {
          ~ enable_components = [
                "SYSTEM_COMPONENTS",
              - "APISERVER",
              - "SCHEDULER",
              - "CADVISOR",
                "KUBELET",
              + "CADVISOR",
              + "SCHEDULER",
              + "APISERVER",
            ]

            # (2 unchanged blocks hidden)
        }

        # (38 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```