### PR TITLE
DM-53379:  Add PPDB subfolders, QServ/EPO cleanup, upgrade provider versions

### DIFF
--- a/environment/foundation/1-org-b/1-org-b.tfvars
+++ b/environment/foundation/1-org-b/1-org-b.tfvars
@@ -51,37 +51,6 @@ gcp_processing_gke_developer_iam_permissions = [
   "roles/storage.objectViewer"
 ]
 
-// QServ IAM Roles
-
-qserv_display_name           = "QServ"
-
-gcp_qserv_administrators_iam_permissions = [
-  "roles/resourcemanager.projectCreator",
-  "roles/container.admin",
-  "roles/editor"
-]
-gcp_qserv_gke_cluster_admins_iam_permissions = [
-  "roles/container.admin",
-  "roles/container.clusterAdmin",
-  "roles/logging.admin",
-  "roles/resourcemanager.projectCreator",
-  "roles/monitoring.admin",
-  "roles/storage.admin",
-  "roles/compute.instanceAdmin",
-  "roles/logging.admin",
-  "roles/file.editor",
-  "roles/compute.networkAdmin",
-  "roles/compute.securityAdmin"
-]
-gcp_qserv_gke_developer_iam_permissions = [
-  "roles/container.clusterViewer",
-  "roles/container.viewer",
-  "roles/container.developer",
-  "roles/logging.viewer",
-  "roles/monitoring.editor",
-  "roles/storage.objectViewer"
-]
-
 // Science Platform
 
 splatform_display_name       = "Science Platform"
@@ -154,9 +123,24 @@ epo_display_name      = "EPO"
 gcp_epo_administrators_iam_permissions = [
   "roles/resourcemanager.projectCreator",
   "roles/container.admin",
-  "roles/editor",
+  "roles/owner",
   "roles/artifactregistry.admin",
   "roles/resourcemanager.folderViewer"
 ]
 
 alert_production_display_name = "Alert Production"
+
+# PPDB
+
+ppdb_display_name = "PPDB"
+
+gcp_ppdb_administrators_iam_permissions = [
+  "roles/bigquery.dataViewer",
+  "roles/bigquery.user",
+  "roles/cloudsql.viewer",
+  "roles/dataproc.viewer",
+  "roles/logging.viewer",
+  "roles/monitoring.editor",
+  "roles/run.viewer",
+  "roles/storage.objectViewer"
+]

--- a/environment/foundation/1-org-b/README.md
+++ b/environment/foundation/1-org-b/README.md
@@ -1,0 +1,80 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.50.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_constants"></a> [constants](#module\_constants) | ../constants | n/a |
+| <a name="module_sub_folders_alert_production"></a> [sub\_folders\_alert\_production](#module\_sub\_folders\_alert\_production) | terraform-google-modules/folders/google | ~> 5.1 |
+| <a name="module_sub_folders_epo"></a> [sub\_folders\_epo](#module\_sub\_folders\_epo) | terraform-google-modules/folders/google | ~> 5.1 |
+| <a name="module_sub_folders_ppdb"></a> [sub\_folders\_ppdb](#module\_sub\_folders\_ppdb) | terraform-google-modules/folders/google | ~> 5.1 |
+| <a name="module_sub_folders_processing"></a> [sub\_folders\_processing](#module\_sub\_folders\_processing) | terraform-google-modules/folders/google | ~> 5.1 |
+| <a name="module_sub_folders_science_platform"></a> [sub\_folders\_science\_platform](#module\_sub\_folders\_science\_platform) | terraform-google-modules/folders/google | ~> 5.1 |
+| <a name="module_sub_folders_square"></a> [sub\_folders\_square](#module\_sub\_folders\_square) | terraform-google-modules/folders/google | ~> 5.1 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_folder_iam_member.gcp_epo_administrators_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_ppdb_administrators_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_processing_administrator_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_processing_gke_cluster_admins_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_processing_gke_developer_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_science_platform_administrator_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_science_platform_gke_cluster_admins_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_science_platform_gke_developer_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_shared_service_org_admin_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_square_administrator_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_square_gke_cluster_admins_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.gcp_square_gke_developer_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_active_folder.alert_production_sub_folder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/active_folder) | data source |
+| [google_active_folder.epo_sub_folder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/active_folder) | data source |
+| [google_active_folder.ppdb_sub_folder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/active_folder) | data source |
+| [google_active_folder.processing_sub_folder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/active_folder) | data source |
+| [google_active_folder.shared_services_folder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/active_folder) | data source |
+| [google_active_folder.splatform_sub_folder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/active_folder) | data source |
+| [google_active_folder.square_sub_folder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/active_folder) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_alert_production_display_name"></a> [alert\_production\_display\_name](#input\_alert\_production\_display\_name) | The display name of the parent folder. | `string` | `"Alert Production"` | no |
+| <a name="input_epo_display_name"></a> [epo\_display\_name](#input\_epo\_display\_name) | The display name of the parent folder. | `string` | `"EPO"` | no |
+| <a name="input_gcp_epo_administrators_iam_permissions"></a> [gcp\_epo\_administrators\_iam\_permissions](#input\_gcp\_epo\_administrators\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/resourcemanager.projectCreator",<br/>  "roles/container.admin",<br/>  "roles/editor"<br/>]</pre> | no |
+| <a name="input_gcp_org_administrators_shared_service_iam_permissions"></a> [gcp\_org\_administrators\_shared\_service\_iam\_permissions](#input\_gcp\_org\_administrators\_shared\_service\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/storage.admin",<br/>  "roles/domains.admin"<br/>]</pre> | no |
+| <a name="input_gcp_ppdb_administrators_iam_permissions"></a> [gcp\_ppdb\_administrators\_iam\_permissions](#input\_gcp\_ppdb\_administrators\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/storage.admin"<br/>]</pre> | no |
+| <a name="input_gcp_processing_administrators_iam_permissions"></a> [gcp\_processing\_administrators\_iam\_permissions](#input\_gcp\_processing\_administrators\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/resourcemanager.projectCreator",<br/>  "roles/container.admin",<br/>  "roles/editor"<br/>]</pre> | no |
+| <a name="input_gcp_processing_gke_cluster_admins_iam_permissions"></a> [gcp\_processing\_gke\_cluster\_admins\_iam\_permissions](#input\_gcp\_processing\_gke\_cluster\_admins\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/container.admin",<br/>  "roles/container.clusterAdmin",<br/>  "roles/logging.admin",<br/>  "roles/resourcemanager.projectCreator",<br/>  "roles/monitoring.admin",<br/>  "roles/storage.admin",<br/>  "roles/compute.instanceAdmin",<br/>  "roles/logging.admin",<br/>  "roles/file.editor",<br/>  "roles/compute.networkAdmin",<br/>  "roles/compute.securityAdmin"<br/>]</pre> | no |
+| <a name="input_gcp_processing_gke_developer_iam_permissions"></a> [gcp\_processing\_gke\_developer\_iam\_permissions](#input\_gcp\_processing\_gke\_developer\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/container.clusterViewer",<br/>  "roles/container.viewer",<br/>  "roles/container.developer",<br/>  "roles/logging.viewer",<br/>  "roles/monitoring.editor",<br/>  "roles/storage.objectViewer"<br/>]</pre> | no |
+| <a name="input_gcp_science_platform_administrators_iam_permissions"></a> [gcp\_science\_platform\_administrators\_iam\_permissions](#input\_gcp\_science\_platform\_administrators\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/resourcemanager.projectCreator",<br/>  "roles/container.admin",<br/>  "roles/editor"<br/>]</pre> | no |
+| <a name="input_gcp_science_platform_gke_cluster_admins_iam_permissions"></a> [gcp\_science\_platform\_gke\_cluster\_admins\_iam\_permissions](#input\_gcp\_science\_platform\_gke\_cluster\_admins\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/container.admin",<br/>  "roles/container.clusterAdmin",<br/>  "roles/logging.admin",<br/>  "roles/resourcemanager.projectCreator",<br/>  "roles/monitoring.admin",<br/>  "roles/storage.admin",<br/>  "roles/compute.instanceAdmin",<br/>  "roles/logging.admin",<br/>  "roles/file.editor",<br/>  "roles/compute.networkAdmin",<br/>  "roles/compute.securityAdmin"<br/>]</pre> | no |
+| <a name="input_gcp_science_platform_gke_developer_iam_permissions"></a> [gcp\_science\_platform\_gke\_developer\_iam\_permissions](#input\_gcp\_science\_platform\_gke\_developer\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/container.clusterViewer",<br/>  "roles/container.viewer",<br/>  "roles/container.developer",<br/>  "roles/logging.viewer",<br/>  "roles/monitoring.editor",<br/>  "roles/storage.objectViewer"<br/>]</pre> | no |
+| <a name="input_gcp_square_administrators_iam_permissions"></a> [gcp\_square\_administrators\_iam\_permissions](#input\_gcp\_square\_administrators\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/resourcemanager.projectCreator",<br/>  "roles/container.admin",<br/>  "roles/editor"<br/>]</pre> | no |
+| <a name="input_gcp_square_gke_cluster_admins_iam_permissions"></a> [gcp\_square\_gke\_cluster\_admins\_iam\_permissions](#input\_gcp\_square\_gke\_cluster\_admins\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/container.admin",<br/>  "roles/container.clusterAdmin",<br/>  "roles/logging.admin",<br/>  "roles/resourcemanager.projectCreator",<br/>  "roles/monitoring.admin",<br/>  "roles/storage.admin",<br/>  "roles/compute.instanceAdmin",<br/>  "roles/logging.admin",<br/>  "roles/file.editor",<br/>  "roles/compute.networkAdmin",<br/>  "roles/compute.securityAdmin"<br/>]</pre> | no |
+| <a name="input_gcp_square_gke_developer_iam_permissions"></a> [gcp\_square\_gke\_developer\_iam\_permissions](#input\_gcp\_square\_gke\_developer\_iam\_permissions) | List of permissions granted to the group. | `list(string)` | <pre>[<br/>  "roles/container.clusterViewer",<br/>  "roles/container.viewer",<br/>  "roles/container.developer",<br/>  "roles/logging.viewer",<br/>  "roles/monitoring.editor",<br/>  "roles/storage.objectViewer"<br/>]</pre> | no |
+| <a name="input_parent_folder"></a> [parent\_folder](#input\_parent\_folder) | Optional - if using a folder for testing. | `string` | `""` | no |
+| <a name="input_ppdb_display_name"></a> [ppdb\_display\_name](#input\_ppdb\_display\_name) | The display name of the parent folder. | `string` | `"PPDB"` | no |
+| <a name="input_processing_display_name"></a> [processing\_display\_name](#input\_processing\_display\_name) | The display name of the parent folder. | `string` | `"Processing"` | no |
+| <a name="input_shared_services_display_name"></a> [shared\_services\_display\_name](#input\_shared\_services\_display\_name) | The display name of the parent folder. | `string` | `"Shared Services"` | no |
+| <a name="input_splatform_display_name"></a> [splatform\_display\_name](#input\_splatform\_display\_name) | The display name of the parent folder. | `string` | `"Science Platform"` | no |
+| <a name="input_square_display_name"></a> [square\_display\_name](#input\_square\_display\_name) | The display name of the parent folder. | `string` | `"SQuaRE"` | no |
+| <a name="input_sub_folder_names"></a> [sub\_folder\_names](#input\_sub\_folder\_names) | List out the sub folders to be created. | `list(string)` | <pre>[<br/>  "Dev",<br/>  "Integration",<br/>  "Production"<br/>]</pre> | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/environment/foundation/1-org-b/data.tf
+++ b/environment/foundation/1-org-b/data.tf
@@ -6,11 +6,6 @@ locals {
 #   Lookup parent folder by folder name
 # ----------------------------------------
 
-data "google_active_folder" "qserv_sub_folder" {
-  parent       = local.parent
-  display_name = var.qserv_display_name
-}
-
 data "google_active_folder" "splatform_sub_folder" {
   parent       = local.parent
   display_name = var.splatform_display_name
@@ -39,4 +34,9 @@ data "google_active_folder" "epo_sub_folder" {
 data "google_active_folder" "alert_production_sub_folder" {
   parent       = local.parent
   display_name = var.alert_production_display_name
+}
+
+data "google_active_folder" "ppdb_sub_folder" {
+  parent       = local.parent
+  display_name = var.ppdb_display_name
 }

--- a/environment/foundation/1-org-b/iam.tf
+++ b/environment/foundation/1-org-b/iam.tf
@@ -1,26 +1,3 @@
-// Qserv Folder
-resource "google_folder_iam_member" "gcp_qserv_gke_cluster_admins_iam_permissions" {
-  for_each = toset(var.gcp_qserv_gke_cluster_admins_iam_permissions)
-  folder   = data.google_active_folder.qserv_sub_folder.name
-  role     = each.value
-  member   = "group:${module.constants.values.groups.gcp_qserv_gke_cluster_admins}"
-}
-
-resource "google_folder_iam_member" "gcp_qserv_gke_developer_iam_permissions" {
-  for_each = toset(var.gcp_qserv_gke_developer_iam_permissions)
-  folder   = data.google_active_folder.qserv_sub_folder.name
-  role     = each.value
-  member   = "group:${module.constants.values.groups.gcp_qserv_gke_developer}"
-}
-
-resource "google_folder_iam_member" "gcp_qserv_administrator_iam_permissions" {
-  for_each = toset(var.gcp_qserv_administrators_iam_permissions)
-  folder   = data.google_active_folder.qserv_sub_folder.name
-  role     = each.value
-  member   = "group:${module.constants.values.groups.gcp_qserv_administrators}"
-}
-
-
 // Science Platform Folder
 resource "google_folder_iam_member" "gcp_science_platform_gke_cluster_admins_iam_permissions" {
   for_each = toset(var.gcp_science_platform_gke_cluster_admins_iam_permissions)
@@ -96,8 +73,16 @@ resource "google_folder_iam_member" "gcp_shared_service_org_admin_iam_permission
 
 // EPO Folder
 resource "google_folder_iam_member" "gcp_epo_administrators_iam_permissions" {
-  for_each = toset(var.gcp_square_administrators_iam_permissions)
+  for_each = toset(var.gcp_epo_administrators_iam_permissions)
   folder   = data.google_active_folder.epo_sub_folder.name
   role     = each.value
   member   = "group:${module.constants.values.groups.gcp_epo_administrators}"
+}
+
+// PPDB Folder
+resource "google_folder_iam_member" "gcp_ppdb_administrators_iam_permissions" {
+  for_each = toset(var.gcp_ppdb_administrators_iam_permissions)
+  folder   = data.google_active_folder.ppdb_sub_folder.name
+  role     = each.value
+  member   = "group:${module.constants.values.groups.gcp_ppdb_administrators}"
 }

--- a/environment/foundation/1-org-b/providers.tf
+++ b/environment/foundation/1-org-b/providers.tf
@@ -6,7 +6,7 @@ terraform {
   backend "gcs" {
   }
   required_providers {
-    google      = "~> 3.1"
-    google-beta = "~> 3.1"
+    google      = "~> 6.0"
+    google-beta = "~> 6.0"
   }
 }

--- a/environment/foundation/1-org-b/sub_folders.tf
+++ b/environment/foundation/1-org-b/sub_folders.tf
@@ -1,7 +1,7 @@
 // Build Sub Folders for Science Platform
 module "sub_folders_science_platform" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
+  version = "~> 5.1"
 
   parent = data.google_active_folder.splatform_sub_folder.name
   names  = var.sub_folder_names
@@ -10,7 +10,7 @@ module "sub_folders_science_platform" {
 // Build Sub Folders for Processing
 module "sub_folders_processing" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
+  version = "~> 5.1"
 
   parent = data.google_active_folder.processing_sub_folder.name
   names  = var.sub_folder_names
@@ -19,7 +19,7 @@ module "sub_folders_processing" {
 // Build Sub Folders for Square
 module "sub_folders_square" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
+  version = "~> 5.1"
 
   parent = data.google_active_folder.square_sub_folder.name
   names  = var.sub_folder_names
@@ -28,7 +28,7 @@ module "sub_folders_square" {
 // Build Sub Folders for EPO
 module "sub_folders_epo" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
+  version = "~> 5.1"
 
   parent = data.google_active_folder.epo_sub_folder.name
   names  = var.sub_folder_names
@@ -37,7 +37,7 @@ module "sub_folders_epo" {
 // Build Sub Folders for Alert Production
 module "sub_folders_alert_production" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
+  version = "~> 5.1"
 
   parent = data.google_active_folder.alert_production_sub_folder.name
   names  = var.sub_folder_names
@@ -46,7 +46,7 @@ module "sub_folders_alert_production" {
 // Build Sub Folders for PPDB
 module "sub_folders_ppdb" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
+  version = "~> 5.1"
 
   parent = data.google_active_folder.ppdb_sub_folder.name
   names  = var.sub_folder_names

--- a/environment/foundation/1-org-b/sub_folders.tf
+++ b/environment/foundation/1-org-b/sub_folders.tf
@@ -1,12 +1,3 @@
-// Build Sub Folders for QServ
-module "sub_folders_qserv" {
-  source  = "terraform-google-modules/folders/google"
-  version = "~> 2.0"
-
-  parent = data.google_active_folder.qserv_sub_folder.name
-  names  = var.sub_folder_names
-}
-
 // Build Sub Folders for Science Platform
 module "sub_folders_science_platform" {
   source  = "terraform-google-modules/folders/google"
@@ -49,5 +40,14 @@ module "sub_folders_alert_production" {
   version = "~> 2.0"
 
   parent = data.google_active_folder.alert_production_sub_folder.name
+  names  = var.sub_folder_names
+}
+
+// Build Sub Folders for PPDB
+module "sub_folders_ppdb" {
+  source  = "terraform-google-modules/folders/google"
+  version = "~> 2.0"
+
+  parent = data.google_active_folder.ppdb_sub_folder.name
   names  = var.sub_folder_names
 }

--- a/environment/foundation/1-org-b/variables.tf
+++ b/environment/foundation/1-org-b/variables.tf
@@ -3,23 +3,6 @@
 # ----------------------------------------
 
 // CLUSTER ADMINS
-variable "gcp_qserv_gke_cluster_admins_iam_permissions" {
-  description = "List of permissions granted to the group."
-  type        = list(string)
-  default = [
-    "roles/container.admin",
-    "roles/container.clusterAdmin",
-    "roles/logging.admin",
-    "roles/resourcemanager.projectCreator",
-    "roles/monitoring.admin",
-    "roles/storage.admin",
-    "roles/compute.instanceAdmin",
-    "roles/logging.admin",
-    "roles/file.editor",
-    "roles/compute.networkAdmin",
-    "roles/compute.securityAdmin"
-  ]
-}
 
 variable "gcp_science_platform_gke_cluster_admins_iam_permissions" {
   description = "List of permissions granted to the group."
@@ -76,18 +59,6 @@ variable "gcp_square_gke_cluster_admins_iam_permissions" {
 }
 
 // CLUSTER DEVELOPERS
-variable "gcp_qserv_gke_developer_iam_permissions" {
-  description = "List of permissions granted to the group."
-  type        = list(string)
-  default = [
-    "roles/container.clusterViewer",
-    "roles/container.viewer",
-    "roles/container.developer",
-    "roles/logging.viewer",
-    "roles/monitoring.editor",
-    "roles/storage.objectViewer",
-  ]
-}
 
 variable "gcp_science_platform_gke_developer_iam_permissions" {
   description = "List of permissions granted to the group."
@@ -130,16 +101,6 @@ variable "gcp_square_gke_developer_iam_permissions" {
 
 // GCP PROJECT ADMINISTRATORS
 
-variable "gcp_qserv_administrators_iam_permissions" {
-  description = "List of permissions granted to the group."
-  type        = list(string)
-  default = [
-    "roles/resourcemanager.projectCreator",
-    "roles/container.admin",
-    "roles/editor"
-  ]
-}
-
 variable "gcp_science_platform_administrators_iam_permissions" {
   description = "List of permissions granted to the group."
   type        = list(string)
@@ -179,7 +140,23 @@ variable "gcp_org_administrators_shared_service_iam_permissions" {
   ]
 }
 
+variable "gcp_epo_administrators_iam_permissions" {
+  description = "List of permissions granted to the group."
+  type        = list(string)
+  default = [
+    "roles/resourcemanager.projectCreator",
+    "roles/container.admin",
+    "roles/editor"
+  ]
+}
 
+variable "gcp_ppdb_administrators_iam_permissions" {
+  description = "List of permissions granted to the group."
+  type        = list(string)
+  default = [
+    "roles/storage.admin",
+  ]
+}
 
 # ----------------------------------------
 #   SUB FOLDER VARIABLES
@@ -189,12 +166,6 @@ variable "parent_folder" {
   description = "Optional - if using a folder for testing."
   type        = string
   default     = ""
-}
-
-variable "qserv_display_name" {
-  description = "The display name of the parent folder."
-  type        = string
-  default     = "QServ"
 }
 
 variable "splatform_display_name" {
@@ -231,6 +202,12 @@ variable "alert_production_display_name" {
   description = "The display name of the parent folder."
   type        = string
   default     = "Alert Production"
+}
+
+variable "ppdb_display_name" {
+  description = "The display name of the parent folder."
+  type        = string
+  default     = "PPDB"
 }
 
 variable "sub_folder_names" {

--- a/environment/foundation/constants/constants.tf
+++ b/environment/foundation/constants/constants.tf
@@ -21,13 +21,12 @@ locals {
       monitoring_viewer = "gcp-monitoring-viewer@lsst.cloud"
       cloudsql_admins   = "gcp-cloudsql-admins@lsst.cloud"
 
-      gcp_qserv_administrators            = "gcp-qserv-administrators@lsst.cloud"
       gcp_science_platform_administrators = "gcp-science-platform-administrators@lsst.cloud"
       gcp_processing_administrators       = "gcp-processing-administrators@lsst.cloud"
       gcp_square_administrators           = "gcp-square-administrators@lsst.cloud"
       gcp_epo_administrators              = "gcp-epo-administrators@lsst.cloud"
+      gcp_ppdb_administrators             = "gcp-ppdb-administrators@lsst.cloud"
 
-      gcp_qserv_gke_cluster_admins            = "gcp-qserv-gke-cluster-admins@lsst.cloud"
       gcp_science_platform_gke_cluster_admins = "gcp-science-platform-gke-cluster-admins@lsst.cloud"
       gcp_processing_gke_cluster_admins       = "gcp-processing-gke-cluster-admins@lsst.cloud"
       gcp_square_gke_cluster_admins           = "gcp-square-gke-cluster-admins@lsst.cloud"
@@ -35,7 +34,6 @@ locals {
       gcp_square_gke_developer           = "gcp-square-gke-developer@lsst.cloud"
       gcp_processing_gke_developer       = "gcp-processing-gke-developer@lsst.cloud"
       gcp_science_platform_gke_developer = "gcp-science-platform-gke-developer@lsst.cloud"
-      gcp_qserv_gke_developer            = "gcp-qserv-gke-developer@lsst.cloud"
     }
 
     // Shared VPC


### PR DESCRIPTION
Adds PPDB subfolders.  QServ folders and permissions removed from Terraform. QServ had previously been manually deleted.  There was an error in EPO where EPO folder permissions were set to the SQuaRE.  Cleaned this up and added EPO variables.  Upgraded the Terraform provider versions to be consistent with other modules in this repo and updated the state locations of folders for the upgrade.