### PR TITLE
DM-55151: Add a storage bucket for DP2

### DIFF
--- a/environment/deployments/data-curation/env/production.tfvars
+++ b/environment/deployments/data-curation/env/production.tfvars
@@ -94,4 +94,4 @@ git_lfs_ro_dev_service_accounts = [
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 14
+# Serial: 15

--- a/environment/deployments/data-curation/main.tf
+++ b/environment/deployments/data-curation/main.tf
@@ -92,7 +92,7 @@ module "storage_bucket_2" {
   storage_class = "REGIONAL"
   location      = "us-central1"
   prefix_name   = "butler-us-central1"
-  suffix_name   = ["dp01-dev", "dp01-int", "dp01", "repo-locations", "dp02-user", "dp1"]
+  suffix_name   = ["dp01-dev", "dp01-int", "dp01", "repo-locations", "dp02-user", "dp1", "dp2"]
   versioning = {
     dp01-dev       = true
     dp01-int       = true
@@ -101,6 +101,7 @@ module "storage_bucket_2" {
     repo-locations = true
     dp02-user      = false
     dp1            = false
+    dp2            = false
   }
   force_destroy = {
     dp01-dev       = true
@@ -111,6 +112,7 @@ module "storage_bucket_2" {
     repo-locations = true
     dp02-user      = true
     dp1            = true
+    dp2            = true
   }
   labels = {
     environment = var.environment
@@ -320,6 +322,13 @@ module "butler_server_account" {
 resource "google_storage_bucket_iam_member" "data_curation_prod_ro_dp1" {
   for_each = toset(["roles/storage.objectViewer", "roles/storage.legacyBucketReader"])
   bucket   = "butler-us-central1-dp1"
+  role     = each.value
+  member   = "serviceAccount:${module.butler_server_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "data_curation_prod_ro_dp2" {
+  for_each = toset(["roles/storage.objectViewer", "roles/storage.legacyBucketReader"])
+  bucket   = "butler-us-central1-dp2"
   role     = each.value
   member   = "serviceAccount:${module.butler_server_account.email}"
 }


### PR DESCRIPTION
Deep coadds for DP2 will now be hosted on Google, so create a GCS bucket to store them.