### PR TITLE
DM-53379: PPDB Services Fix

### DIFF
--- a/environment/deployments/ppdb/env/dev-services.tfvars
+++ b/environment/deployments/ppdb/env/dev-services.tfvars
@@ -17,4 +17,4 @@ trigger_stage_chunk_cloud_run_temp_location       = "gs://ppdb-dev-dataflow/temp
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 1
+# Serial: 2

--- a/environment/deployments/ppdb/services/artifact-registry.tf
+++ b/environment/deployments/ppdb/services/artifact-registry.tf
@@ -1,6 +1,6 @@
 resource "google_artifact_registry_repository" "ppdb_repo" {
   location      = "us-central1"
-  repository_id = "ppdb_repo"
+  repository_id = "ppdb-repo"
   description   = "Docker repository for PPDB Container images"
   format        = "DOCKER"
   project       = local.project_id

--- a/environment/deployments/ppdb/services/promote-chunks.tf
+++ b/environment/deployments/ppdb/services/promote-chunks.tf
@@ -54,8 +54,8 @@ resource "google_cloud_run_v2_service" "promote_chunks" {
     }
 
     containers {
-      # This image serves as a placeholder for the initial provision
-      image = "us-central1-docker.pkg.dev/${local.project_id}/${google_artifact_registry_repository.ppdb_repo.repository_id}/promote-chunks:latest"
+      # This image serves as a placeholder for the initial provision so that the Cloud run instance can be created.  It is overwritten by the application gcloud deploy.
+      image = "gcr.io/cloudrun/hello"
 
       resources {
         startup_cpu_boost = true

--- a/environment/deployments/ppdb/services/track-chunk.tf
+++ b/environment/deployments/ppdb/services/track-chunk.tf
@@ -83,8 +83,8 @@ resource "google_cloud_run_v2_service" "track_chunk" {
     }
 
     containers {
-      # This image serves as a placeholder for the initial provision
-      image = "us-central1-docker.pkg.dev/${data.terraform_remote_state.ppdb_project.outputs.project_id}/${google_artifact_registry_repository.ppdb_repo.repository_id}/track-chunk:latest"
+      # This image serves as a placeholder for the initial provision so that the Cloud run instance can be created.  It is overwritten by the application gcloud deploy.
+      image = "gcr.io/cloudrun/hello"
 
       resources {
         startup_cpu_boost = true

--- a/environment/deployments/ppdb/services/trigger-stage-chunk.tf
+++ b/environment/deployments/ppdb/services/trigger-stage-chunk.tf
@@ -84,8 +84,8 @@ resource "google_cloud_run_v2_service" "trigger_stage_chunk" {
     }
 
     containers {
-      # This image serves as a placeholder for the initial provision
-      image = "us-central1-docker.pkg.dev/${local.project_id}/${google_artifact_registry_repository.ppdb_repo.repository_id}/trigger-stage-chunk:latest"
+      # This image serves as a placeholder for the initial provision so that the Cloud run instance can be created.  It is overwritten by the application gcloud deploy.
+      image = "gcr.io/cloudrun/hello"
 
       resources {
         startup_cpu_boost = true


### PR DESCRIPTION
Fix artifact registry name as Google does not allow underscores in name.  Set container image to dummy image since application deployment will overwrite.  This solves chicken and egg problem since image image is not built before image provisioned.