### PR TITLE
Give /rubin in prod 5T more

### DIFF
--- a/environment/deployments/science-platform/env/production.tfvars
+++ b/environment/deployments/science-platform/env/production.tfvars
@@ -81,7 +81,7 @@ netapp_definitions = [
   },
   { name               = "rubin"
     service_level      = "PREMIUM"
-    capacity_gib       = 15360
+    capacity_gib       = 20480
     unix_permissions   = "0755"
     snapshot_directory = false
     backups_enabled    = true


### PR DESCRIPTION
We ran out of space copying dp2 data.

We shouldn't have, but nevertheless here we are.

So grow it so we can get the data copied and then we will figure it out and shrink it later.
