### PR TITLE
DM-55588: Update PPDB Cloud Run

### DIFF
--- a/environment/deployments/ppdb/env/dev-services.tfvars
+++ b/environment/deployments/ppdb/env/dev-services.tfvars
@@ -4,14 +4,17 @@ application_name = "ppdb"
 state_bucket     = "lsst-terraform-state"
 
 # Promote Chunks Cloud Run
-promote_chunks_cloud_run_ppdb_config_uri    = "gs://ppdb-dev-config/ppdb_dev.yaml"
+promote_chunks_cloud_run_ppdb_config_uri = "gs://ppdb-dev-config/ppdb_dev.yaml"
+promote_chunks_runtime = "python313"
 
 # Track Chunk Cloud Run
-track_chunk_cloud_run_ppdb_config_uri    = "gs://ppdb-dev-config/ppdb_dev.yaml"
+track_chunk_cloud_run_ppdb_config_uri = "gs://ppdb-dev-config/ppdb_dev.yaml"
+track_chunk_runtime = "python313"
 
 # Trigger Stage Chunks Cloud Run
-trigger_stage_chunk_cloud_run_dataflow_template_path    = "gs://ppdb-dev-dataflow/templates/stage_chunk_flex_template.json"
-trigger_stage_chunk_cloud_run_temp_location       = "gs://ppdb-dev-dataflow/temp"
+trigger_stage_chunk_cloud_run_dataflow_template_path = "gs://ppdb-dev-dataflow/templates/stage_chunk_flex_template.json"
+trigger_stage_chunk_cloud_run_temp_location = "gs://ppdb-dev-dataflow/temp"
+trigger_stage_chunk_runtime = "python313"
 
 # GitHub CI
 create_gh_ci_sa = true

--- a/environment/deployments/ppdb/env/dev.tfvars
+++ b/environment/deployments/ppdb/env/dev.tfvars
@@ -58,4 +58,4 @@ activate_apis = [
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 5
+# Serial: 6

--- a/environment/deployments/ppdb/services/cloudrun-build.tf
+++ b/environment/deployments/ppdb/services/cloudrun-build.tf
@@ -1,0 +1,24 @@
+# Track Chunks Build Account
+resource "google_service_account" "cloudrun_build" {
+  account_id   = "cloud-run-build"
+  display_name = "Terraform-managed service account for Cloud Run builds"
+  project      = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_build_build_object_viewer" {
+  project = local.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.cloudrun_build.email}"
+}
+
+resource "google_project_iam_member" "cloudrun_build_artifact_registry_writer" {
+  project = local.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.cloudrun_build.email}"
+}
+
+resource "google_project_iam_member" "cloudrun_build_logs_writer" {
+  project = local.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloudrun_build.email}"
+}

--- a/environment/deployments/ppdb/services/cloudrun-deploy.tf
+++ b/environment/deployments/ppdb/services/cloudrun-deploy.tf
@@ -1,0 +1,49 @@
+# PPDB Cloud Run Deploy Service Account
+
+resource "google_service_account" "cloudrun_deploy" {
+  account_id   = "cloudrun-deploy"
+  display_name = "Terraform-managed service account to deploy Cloud Run functions"
+  project      = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_deploy_functions_developer" {
+  role    = "roles/cloudfunctions.developer"
+  member  = "serviceAccount:${google_service_account.cloudrun_deploy.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_deploy_run_developer" {
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.cloudrun_deploy.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_deploy_service_account_user" {
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.cloudrun_deploy.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_deploy_builds_editor" {
+  role    = "roles/cloudbuild.builds.editor"
+  member  = "serviceAccount:${google_service_account.cloudrun_deploy.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_deploy_artifact_registry_writer" {
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.cloudrun_deploy.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_deploy_storage_admin" {
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.cloudrun_deploy.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "cloudrun_deploy_storage_object_admin" {
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.cloudrun_deploy.email}"
+  project = local.project_id
+}

--- a/environment/deployments/ppdb/services/github-ci.tf
+++ b/environment/deployments/ppdb/services/github-ci.tf
@@ -14,6 +14,13 @@ resource "google_project_iam_member" "github_ci_bigquery_data_editor" {
   project = local.project_id
 }
 
+resource "google_project_iam_member" "github_ci_bigquery_job_user" {
+  for_each = var.create_gh_ci_sa ? { "enabled" = true } : {}
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.gh_ci["enabled"].email}"
+  project = local.project_id
+}
+
 resource "google_project_iam_member" "github_ci_storage_admin" {
   for_each = var.create_gh_ci_sa ? { "enabled" = true } : {}
   role    = "roles/storage.admin"

--- a/environment/deployments/ppdb/services/locals.tf
+++ b/environment/deployments/ppdb/services/locals.tf
@@ -1,3 +1,17 @@
 locals {
   project_id = data.terraform_remote_state.ppdb_project.outputs.project_id
+
+  network = replace(
+          data.terraform_remote_state.ppdb_project.outputs.network_self_link,
+          "https://www.googleapis.com/compute/v1/",
+          ""
+        )
+  subnet = replace(
+      one([
+        for s in data.terraform_remote_state.ppdb_project.outputs.subnets_self_links : s
+        if can(regex("subnet-us-central1-01", s))
+      ]),
+      "https://www.googleapis.com/compute/v1/",
+      ""
+    )
 }

--- a/environment/deployments/ppdb/services/promote-chunks.tf
+++ b/environment/deployments/ppdb/services/promote-chunks.tf
@@ -36,62 +36,69 @@ resource "google_project_iam_member" "cloudrun_promote_chunks_sql_instance_user"
   project = local.project_id
 }
 
-# Cloud Run 
-resource "google_cloud_run_v2_service" "promote_chunks" {
-  name     = "promote-chunks"
-  project  = local.project_id
-  location = "us-central1"
+# Cloud Run Functions Gen2 Definition
+resource "google_cloudfunctions2_function" "promote_chunks" {
+  name        = "promote-chunks"
+  project     = local.project_id
+  location    = var.region
+  description = "Promotes Chunks"
 
-  template {
-    service_account = google_service_account.cloudrun_promote_chunks.email
+  build_config {
+    runtime         = var.promote_chunks_runtime
+    entry_point     = "promote_chunks"
+    service_account = google_service_account.cloudrun_build.id
 
-    timeout                          = var.promote_chunks_cloud_run_timeout
-    max_instance_request_concurrency = var.promote_chunks_cloud_run_concurrency
-
-    scaling {
-      min_instance_count = var.promote_chunks_cloud_run_min_instance_count
-      max_instance_count = var.promote_chunks_cloud_run_max_instance_count
-    }
-
-    containers {
-      # This image serves as a placeholder for the initial provision so that the Cloud run instance can be created.  It is overwritten by the application gcloud deploy.
-      image = "gcr.io/cloudrun/hello"
-
-      resources {
-        startup_cpu_boost = true
-        cpu_idle          = true
-
-        limits = {
-          cpu    = var.promote_chunks_cloud_run_cpu_limit
-          memory = var.promote_chunks_cloud_run_memory_limit
-        }
-      }
-
-      ports {
-        container_port = 8080
-      }
-
-      env {
-        name  = "PPDB_CONFIG_URI"
-        value = var.promote_chunks_cloud_run_ppdb_config_uri
-      }
-
-      env {
-        name  = "PPDB_USE_SECRET_MANAGER"
-        value = var.promote_chunks_cloud_run_ppdb_use_secret_manager
-      }
-
-      env {
-        name  = "LOG_EXECUTION_ID"
-        value = var.promote_chunks_cloud_run_log_execution_id
+    # Placeholder source code bucket/object for initial creation
+    source {
+      storage_source {
+        bucket = google_storage_bucket_object.placeholder_zip_promote_chunks.bucket
+        object = google_storage_bucket_object.placeholder_zip_promote_chunks.name
       }
     }
   }
 
+  service_config {
+    available_memory                 = var.promote_chunks_cloud_run_memory_limit
+    service_account_email            = google_service_account.cloudrun_promote_chunks.email
+    min_instance_count               = var.promote_chunks_cloud_run_min_instance_count
+    max_instance_count               = var.promote_chunks_cloud_run_max_instance_count
+    max_instance_request_concurrency = var.promote_chunks_cloud_run_concurrency
+    timeout_seconds                  = var.promote_chunks_cloud_run_timeout
+
+    direct_vpc_network_interface {
+      network    = local.network
+      subnetwork = local.subnet
+    }
+    direct_vpc_egress = "VPC_EGRESS_PRIVATE_RANGES_ONLY"
+
+    environment_variables = {
+      PPDB_CONFIG_URI                   = var.promote_chunks_cloud_run_ppdb_config_uri
+      PPDB_USE_SECRET_MANAGER           = var.promote_chunks_cloud_run_ppdb_use_secret_manager
+    }
+  }
+
+  # Instructs Terraform to ignore modifications to the source code artifact made by CI
   lifecycle {
-    # Keeps Terraform from reverting the image during future applies
     ignore_changes = [
-      template[0].containers[0].image,
+      build_config[0].source,
     ]
   }
+}
+
+# Dummy zip file to build function
+data "archive_file" "dummy_source_promote_chunks" {
+  type        = "zip"
+  output_path = "${path.module}/dummy_source_promote_chunks.zip"
+
+  source {
+    content  = "def promote_chunks(event, context=None):\n    return 'OK'"
+    filename = "main.py"
+  }
+}
+
+# Upload the dummy zip to Cloud Storage
+resource "google_storage_bucket_object" "placeholder_zip_promote_chunks" {
+  name   = "source/placeholder-promote-chunks.zip"
+  bucket = google_storage_bucket.config.id
+  source = data.archive_file.dummy_source_promote_chunks.output_path
 }

--- a/environment/deployments/ppdb/services/track-chunk.tf
+++ b/environment/deployments/ppdb/services/track-chunk.tf
@@ -17,6 +17,12 @@ resource "google_project_iam_member" "cloudrun_track_chunks_sql_instance_user" {
   member  = "serviceAccount:${google_service_account.cloudrun_track_chunks.email}"
 }
 
+resource "google_storage_bucket_iam_member" "cloudrun_track_chunks_storage_viewer_configs" {
+  bucket = google_storage_bucket.config.id
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.cloudrun_track_chunks.email}"
+}
+
 # Dedicated Service Account for Eventarc
 resource "google_service_account" "eventarc_sa_track_chunk" {
   project      = local.project_id
@@ -42,7 +48,7 @@ resource "google_project_iam_member" "run_invoker_track_chunk" {
 resource "google_eventarc_trigger" "pubsub_trigger_track_chunk" {
   name     = "track-chunk"
   project  = local.project_id
-  location = "us-central1"
+  location = var.region
 
   service_account = google_service_account.eventarc_sa_track_chunk.email
 
@@ -59,67 +65,87 @@ resource "google_eventarc_trigger" "pubsub_trigger_track_chunk" {
 
   destination {
     cloud_run_service {
-      service = google_cloud_run_v2_service.track_chunk.name
-      region  = "us-central1"
+      service = google_cloudfunctions2_function.track_chunk.name
+      region = var.region
     }
   }
 }
 
-# Cloud Run Definition
-resource "google_cloud_run_v2_service" "track_chunk" {
-  name     = "track-chunk"
-  project  = local.project_id
-  location = "us-central1"
+# Cloud Run Functions Gen2 Definition
+resource "google_cloudfunctions2_function" "track_chunk" {
+  name        = "track-chunk"
+  project     = local.project_id
+  location    = var.region
+  description = "Tracks processing chunks"
 
-  template {
-    service_account = google_service_account.cloudrun_track_chunks.email
+  build_config {
+    runtime         = var.track_chunk_runtime
+    entry_point     = "track_chunk"
+    service_account = google_service_account.cloudrun_build.id
 
-    timeout                          = var.track_chunk_cloud_run_timeout
-    max_instance_request_concurrency = var.track_chunk_cloud_run_concurrency
-
-    scaling {
-      min_instance_count = var.track_chunk_cloud_run_min_instance_count
-      max_instance_count = var.track_chunk_cloud_run_max_instance_count
-    }
-
-    containers {
-      # This image serves as a placeholder for the initial provision so that the Cloud run instance can be created.  It is overwritten by the application gcloud deploy.
-      image = "gcr.io/cloudrun/hello"
-
-      resources {
-        startup_cpu_boost = true
-        cpu_idle          = true
-
-        limits = {
-          cpu    = var.track_chunk_cloud_run_cpu_limit
-          memory = var.track_chunk_cloud_run_memory_limit
-        }
-      }
-
-      ports {
-        container_port = 8080
-      }
-
-      env {
-        name  = "PPDB_CONFIG_URI"
-        value = var.track_chunk_cloud_run_ppdb_config_uri
-      }
-
-      env {
-        name  = "PPDB_USE_SECRET_MANAGER"
-        value = var.track_chunk_cloud_run_ppdb_use_secret_manager
-      }
-      env {
-        name  = "LOG_EXECUTION_ID"
-        value = var.track_chunk_cloud_run_log_execution_id
+    # Placeholder source code bucket/object for initial creation
+    source {
+      storage_source {
+        bucket = google_storage_bucket_object.placeholder_zip_track_chunk.bucket
+        object = google_storage_bucket_object.placeholder_zip_track_chunk.name
       }
     }
   }
 
+  service_config {
+    available_memory                 = var.track_chunk_cloud_run_memory_limit
+    service_account_email            = google_service_account.cloudrun_track_chunks.email
+    min_instance_count               = var.track_chunk_cloud_run_min_instance_count
+    max_instance_count               = var.track_chunk_cloud_run_max_instance_count
+    max_instance_request_concurrency = var.track_chunk_cloud_run_concurrency
+    timeout_seconds                  = var.track_chunk_cloud_run_timeout
+
+    direct_vpc_network_interface {
+      network    = local.network
+      subnetwork = local.subnet
+    }
+    direct_vpc_egress = "VPC_EGRESS_PRIVATE_RANGES_ONLY"
+
+    environment_variables = {
+      PPDB_CONFIG_URI                   = var.track_chunk_cloud_run_ppdb_config_uri
+      PPDB_USE_SECRET_MANAGER           = var.track_chunk_cloud_run_ppdb_use_secret_manager
+      CLOUDSQL_ENABLED                  = "true"
+      CLOUDSQL_IP_TYPE                  = "private"
+      CLOUDSQL_INSTANCE_CONNECTION_NAME = "${local.project_id}:${var.region}:${var.environment}"
+      CLOUDSQL_USER                     = "${google_service_account.cloudrun_track_chunks.account_id}@${local.project_id}.iam"
+      CLOUDSQL_DB_NAME                  = "ppdb-chunk-tracking"
+    }
+  }
+
+  event_trigger {
+    trigger_region = var.region
+    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic   = "projects/${local.project_id}/topics/track-chunk-topic"
+    retry_policy   = var.track_chunk_cloud_run_retry_policy
+  }
+
+  # Instructs Terraform to ignore modifications to the source code artifact made by CI
   lifecycle {
-    # Keeps Terraform from reverting the image during future applies
     ignore_changes = [
-      template[0].containers[0].image,
+      build_config[0].source,
     ]
   }
+}
+
+# Dummy zip file to build function
+data "archive_file" "dummy_source_track_chunk" {
+  type        = "zip"
+  output_path = "${path.module}/dummy_source_track_chunk.zip"
+
+  source {
+    content  = "def track_chunk(event, context=None):\n    return 'OK'"
+    filename = "main.py"
+  }
+}
+
+# Upload the dummy zip to Cloud Storage
+resource "google_storage_bucket_object" "placeholder_zip_track_chunk" {
+  name   = "source/placeholder-track-chunk.zip"
+  bucket = google_storage_bucket.config.id
+  source = data.archive_file.dummy_source_track_chunk.output_path
 }

--- a/environment/deployments/ppdb/services/trigger-stage-chunk.tf
+++ b/environment/deployments/ppdb/services/trigger-stage-chunk.tf
@@ -43,7 +43,7 @@ resource "google_project_iam_member" "run_invoker_trigger_stage_chunk" {
 resource "google_eventarc_trigger" "pubsub_trigger_trigger_stage_chunk" {
   name     = "trigger-stage-chunk"
   project  = local.project_id
-  location = "us-central1"
+  location = var.region
 
   service_account = google_service_account.eventarc_sa_trigger_stage_chunk.email
 
@@ -60,93 +60,81 @@ resource "google_eventarc_trigger" "pubsub_trigger_trigger_stage_chunk" {
 
   destination {
     cloud_run_service {
-      service = google_cloud_run_v2_service.trigger_stage_chunk.name
-      region  = "us-central1"
+      service = google_cloudfunctions2_function.trigger_stage_chunk.name
+      region  = var.region
     }
   }
 }
 
-# Cloud Run Definition
-resource "google_cloud_run_v2_service" "trigger_stage_chunk" {
-  name     = "trigger-stage-chunk"
-  project  = local.project_id
-  location = "us-central1"
+# Cloud Run Functions Gen2 Definition
+resource "google_cloudfunctions2_function" "trigger_stage_chunk" {
+  name        = "trigger-stage-chunk"
+  project     = local.project_id
+  location    = var.region
+  description = "Triggers Stage Chunks"
 
-  template {
-    service_account = google_service_account.cloudrun_trigger_stage_chunk.email
+  build_config {
+    runtime         = var.trigger_stage_chunk_runtime
+    entry_point     = "trigger_stage_chunk"
+    service_account = google_service_account.cloudrun_build.id
 
-    timeout                          = var.trigger_stage_chunk_cloud_run_timeout
-    max_instance_request_concurrency = var.trigger_stage_chunk_cloud_run_concurrency
-
-    scaling {
-      min_instance_count = var.promote_chunks_cloud_run_min_instance_count
-      max_instance_count = var.promote_chunks_cloud_run_max_instance_count
-    }
-
-    containers {
-      # This image serves as a placeholder for the initial provision so that the Cloud run instance can be created.  It is overwritten by the application gcloud deploy.
-      image = "gcr.io/cloudrun/hello"
-
-      resources {
-        startup_cpu_boost = true
-        cpu_idle          = true
-
-        limits = {
-          cpu    = var.trigger_stage_chunk_cloud_run_cpu_limit
-          memory = var.trigger_stage_chunk_cloud_run_memory_limit
-        }
-      }
-
-      ports {
-        container_port = 8080
-      }
-
-      env {
-        name  = "DATAFLOW_TEMPLATE_PATH"
-        value = var.trigger_stage_chunk_cloud_run_dataflow_template_path
-      }
-
-      env {
-        name  = "LOG_LEVEL"
-        value = var.trigger_stage_chunk_cloud_run_log_level
-      }
-
-      env {
-        name  = "PROJECT_ID"
-        value = local.project_id
-      }
-
-      env {
-        name  = "REGION"
-        value = "us-central1"
-      }
-
-      env {
-        name  = "SERVICE_ACCOUNT_EMAIL"
-        value = google_service_account.cloudrun_trigger_stage_chunk.email
-      }
-
-      env {
-        name  = "TEMP_LOCATION"
-        value = var.trigger_stage_chunk_cloud_run_temp_location
-      }
-
-      env {
-        name  = "TOPIC_NAME"
-        value = google_pubsub_topic.track_chunk_topic.name
-      }
-
-      env {
-        name  = "LOG_EXECUTION_ID"
-        value = var.trigger_stage_chunk_cloud_run_log_execution_id
+    # Placeholder source code bucket/object for initial creation
+    source {
+      storage_source {
+        bucket = google_storage_bucket_object.placeholder_zip_trigger_stage_chunk.bucket
+        object = google_storage_bucket_object.placeholder_zip_trigger_stage_chunk.name
       }
     }
   }
 
+  service_config {
+    available_memory                 = var.trigger_stage_chunk_cloud_run_memory_limit
+    service_account_email            = google_service_account.cloudrun_trigger_stage_chunk.email
+    min_instance_count               = var.trigger_stage_chunk_cloud_run_min_instance_count
+    max_instance_count               = var.trigger_stage_chunk_cloud_run_max_instance_count
+    max_instance_request_concurrency = var.trigger_stage_chunk_cloud_run_concurrency
+    timeout_seconds                  = var.trigger_stage_chunk_cloud_run_timeout
+
+    direct_vpc_network_interface {
+      network    = local.network
+      subnetwork = local.subnet
+    }
+    direct_vpc_egress = "VPC_EGRESS_PRIVATE_RANGES_ONLY"
+
+    environment_variables = {
+      DATAFLOW_TEMPLATE_PATH = var.trigger_stage_chunk_cloud_run_dataflow_template_path
+      LOG_LEVEL              = var.trigger_stage_chunk_cloud_run_log_level
+      PROJECT_ID             = local.project_id
+      REGION                 = var.region
+      SERVICE_ACCOUNT_EMAIL  = google_service_account.cloudrun_trigger_stage_chunk.email
+      TEMP_LOCATION          = var.trigger_stage_chunk_cloud_run_temp_location
+      TOPIC_NAME             = google_pubsub_topic.track_chunk_topic.name
+      LOG_EXECUTION_ID       = var.trigger_stage_chunk_cloud_run_log_execution_id
+    }
+  }
+
+  # Instructs Terraform to ignore modifications to the source code artifact made by CI
   lifecycle {
-    # Keeps Terraform from reverting the image during future applies
     ignore_changes = [
-      template[0].containers[0].image,
+      build_config[0].source,
     ]
   }
+}
+
+# Dummy zip file to build function
+data "archive_file" "dummy_source_trigger_stage_chunk" {
+  type        = "zip"
+  output_path = "${path.module}/dummy_source_trigger_stage_chunk.zip"
+
+  source {
+    content  = "def trigger_stage_chunk(event, context=None):\n    return 'OK'"
+    filename = "main.py"
+  }
+}
+
+# Upload the dummy zip to Cloud Storage
+resource "google_storage_bucket_object" "placeholder_zip_trigger_stage_chunk" {
+  name   = "source/placeholder-trigger-stage-chunk.zip"
+  bucket = google_storage_bucket.config.id
+  source = data.archive_file.dummy_source_trigger_stage_chunk.output_path
 }

--- a/environment/deployments/ppdb/services/usdf-replication.tf
+++ b/environment/deployments/ppdb/services/usdf-replication.tf
@@ -30,3 +30,9 @@ resource "google_storage_bucket_iam_member" "usdf_replication_gcs" {
   role   = "roles/storage.objectUser"
   member = "serviceAccount:${google_service_account.usdf_replication.email}"
 }
+
+resource "google_storage_bucket_iam_member" "usdf_replication_gcs_config_viewer" {
+  bucket = google_storage_bucket.config.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.usdf_replication.email}"
+}

--- a/environment/deployments/ppdb/services/variables.tf
+++ b/environment/deployments/ppdb/services/variables.tf
@@ -13,7 +13,13 @@ variable "environment" {
   type        = string
 }
 
-// BigQuery
+variable "region" {
+  description = "The GCP region to run resources"
+  type        = string
+  default     = "us-central1"
+}
+
+# BigQuery
 
 variable "bigquery_max_time_travel_hours" {
   description = "Defines the time travel window in hours. The value can be from 48 to 168 hours (2 to 7 days)"
@@ -21,7 +27,7 @@ variable "bigquery_max_time_travel_hours" {
   default     = "168"
 }
 
-// Cloud Storage
+# Cloud Storage
 
 variable "config_gcs_storage_class" {
   description = "The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE"
@@ -94,8 +100,8 @@ variable "promote_chunks_cloud_run_max_instance_count" {
 
 variable "promote_chunks_cloud_run_timeout" {
   description = "Max time execution can take"
-  default     = "900s"
-  type        = string
+  default     = "900"
+  type        = number
 }
 
 variable "promote_chunks_cloud_run_concurrency" {
@@ -112,7 +118,7 @@ variable "promote_chunks_cloud_run_cpu_limit" {
 
 variable "promote_chunks_cloud_run_memory_limit" {
   description = "Memory limit"
-  default     = "4Gi"
+  default     = "16Gi"
   type        = string
 }
 
@@ -135,6 +141,17 @@ variable "promote_chunks_cloud_run_log_execution_id" {
 
 }
 
+variable "promote_chunks_runtime" {
+  description = "Runtime for Cloud Run Functions"
+  type        = string
+}
+
+variable "promote_chunks_cloud_run_retry_policy" {
+  description = "Cloud Run retry policy"
+  default     = "RETRY_POLICY_DO_NOT_RETRY"
+  type        = string
+}
+
 # Track Chunk Cloud Run
 
 variable "track_chunk_cloud_run_min_instance_count" {
@@ -151,8 +168,8 @@ variable "track_chunk_cloud_run_max_instance_count" {
 
 variable "track_chunk_cloud_run_timeout" {
   description = "Max time execution can take"
-  default     = "60s"
-  type        = string
+  default     = 60
+  type        = number
 }
 
 variable "track_chunk_cloud_run_concurrency" {
@@ -182,14 +199,17 @@ variable "track_chunk_cloud_run_ppdb_use_secret_manager" {
   description = "Flag to use GCP Secret Manager"
   default     = true
   type        = bool
-
 }
 
-variable "track_chunk_cloud_run_log_execution_id" {
-  description = "Flag to log execution id"
-  default     = true
-  type        = bool
+variable "track_chunk_runtime" {
+  description = "Runtime for Cloud Run Functions"
+  type        = string
+}
 
+variable "track_chunk_cloud_run_retry_policy" {
+  description = "Cloud Run retry policy"
+  default     = "RETRY_POLICY_DO_NOT_RETRY"
+  type        = string
 }
 
 # Trigger Stage Chunk Cloud Run
@@ -208,8 +228,8 @@ variable "trigger_stage_chunk_cloud_run_max_instance_count" {
 
 variable "trigger_stage_chunk_cloud_run_timeout" {
   description = "Max time execution can take"
-  default     = "900s"
-  type        = string
+  default     = "900"
+  type        = number
 }
 
 variable "trigger_stage_chunk_cloud_run_concurrency" {
@@ -249,6 +269,11 @@ variable "trigger_stage_chunk_cloud_run_log_execution_id" {
 
 variable "trigger_stage_chunk_cloud_run_temp_location" {
   description = "Temp location"
+  type        = string
+}
+
+variable "trigger_stage_chunk_runtime" {
+  description = "Runtime for Cloud Run Functions"
   type        = string
 }
 

--- a/environment/deployments/ppdb/variables.tf
+++ b/environment/deployments/ppdb/variables.tf
@@ -77,14 +77,22 @@ variable "project_iam_permissions" {
   default = [
     "roles/artifactregistry.admin",
     "roles/bigquery.admin",
+    "roles/bigquery.dataViewer",
+    "roles/bigquery.user",
+    "roles/run.admin",
     "roles/cloudsql.admin",
+    "roles/cloudsql.viewer",
     "roles/dataflow.admin",
+    "roles/iam.admin",
     "roles/iam.serviceAccountKeyAdmin",
     "roles/logging.admin",
+    "roles/bigquery.admin",
     "roles/monitoring.admin",
     "roles/pubsub.admin",
     "roles/run.admin",
+    "roles/serviceaccount.user",
     "roles/storage.admin",
+    "roles/storage.objectviewer",
     "roles/compute.securityAdmin"
   ]
 }


### PR DESCRIPTION
Reconfigure Cloud Run for Cloud Functions Gen 2.  Fix permissions.

## Change Summary

- Reconfigure the PPDB Cloud Run workloads to use Cloud Functions Gen 2 for:
  - `promote-chunks`
  - `track-chunk`
  - `trigger-stage-chunk`
- Add dedicated Terraform-managed service accounts for Cloud Run build and deploy workflows, with the required IAM roles for:
  - Cloud Build
  - Artifact Registry
  - Logging
  - Cloud Functions / Cloud Run deployment
  - Storage access
- Update PPDB service definitions to use:
  - runtime variables (`python313`)
  - Cloud Functions build/service config blocks
  - placeholder source zip artifacts for initial provisioning
  - VPC network/subnetwork attachment and private egress settings
- Adjust function environment configuration, including Cloud SQL-related settings for `track-chunk`.
- Add supporting locals for network and subnet resolution from remote state outputs.
- Extend variable definitions to support the Gen 2 configuration changes, including:
  - runtime inputs
  - numeric timeout values
  - retry policy settings
  - increased memory for `promote-chunks`
- Grant additional GitHub CI permissions for BigQuery job execution.
- Expand project-level IAM permissions needed by the PPDB deployment.
- Bump the `dev.tfvars` serial to force Terraform to apply the updated environment configuration.

Generated by Copilot