### PR TITLE
DM-55716: idfprod - Add AMD user lab nodepool

### DIFF
--- a/environment/deployments/science-platform/env/integration-new-gke.tfvars
+++ b/environment/deployments/science-platform/env/integration-new-gke.tfvars
@@ -76,9 +76,6 @@ node_pools = [
 node_pools_labels = {
   core-pool = {
     infrastructure = "ok",
-  },
-  user-lab-pool-amd = {
-    schedule-user-labs: "yes"
   }
 }
 

--- a/environment/deployments/science-platform/env/production-new-gke.tfvars
+++ b/environment/deployments/science-platform/env/production-new-gke.tfvars
@@ -52,6 +52,27 @@ node_pools = [
     enable_secure_boot = true
     disk_size_gb       = "300"
     disk_type          = "pd-ssd"
+  },
+
+  # Google Cloud has no more capacity in us-central1-b for n2-highmem-16s on
+  # 2026-08-04. Provision an AMD nodepool with the same size and tier of
+  # instance; these seem to be available
+  {
+    name               = "user-lab-pool-amd"
+    machine_type       = "n2d-highmem-16"
+    node_locations     = "us-central1-b"
+    local_ssd_count    = 0
+    auto_repair        = true
+    auto_upgrade       = true
+    preemptible        = false
+    autoscaling        = true
+    initial_node_count = 1
+    min_count          = 1
+    max_count          = 100
+    image_type         = "cos_containerd"
+    enable_secure_boot = true
+    disk_size_gb       = "300"
+    disk_type          = "pd-ssd"
   }
 ]
 
@@ -63,6 +84,13 @@ node_pools_labels = {
 
 node_pools_taints = {
   "user-lab-pool" = [
+    {
+      key    = "nublado.lsst.io/permitted"
+      value  = "true"
+      effect = "NO_EXECUTE"
+    }
+  ]
+  "user-lab-pool-amd" = [
     {
       key    = "nublado.lsst.io/permitted"
       value  = "true"


### PR DESCRIPTION
Google Cloud has no more capacity in us-central1-b for n2-highmem-16s on 2026-08-04. Provision an AMD nodepool with the same size and tier of instance; these seem to be available.