### PR TITLE
DM-5588:  Tap Service Account Output Dev

### DIFF
--- a/environment/deployments/science-platform/cloudsql/outputs.tf
+++ b/environment/deployments/science-platform/cloudsql/outputs.tf
@@ -1,0 +1,4 @@
+output "service_accounts_map" {
+  description = "Service Accounts map"
+  value       = module.service_accounts.service_accounts_map
+}

--- a/environment/deployments/science-platform/env/dev-cloudsql.tfvars
+++ b/environment/deployments/science-platform/env/dev-cloudsql.tfvars
@@ -25,4 +25,4 @@ science_platform_db_maintenance_window_update_track = "canary"
 science_platform_backups_enabled                    = true
 
 # Increase this number to force Terraform to update the dev environment.
-# Serial: 42
+# Serial: 43


### PR DESCRIPTION
Add output of RSP Service accounts to Terraform outputs.  This is needed so that the PPDB Terraform can read the service account name from state to add permissions to the PPDB BigQuery Datasets.  The output is for all SAs so that it can be used for other needs in the future to read SAs name from state.