### PR TITLE
DM-55588: Add TAP SA permissions to PPDB BigQuery

### DIFF
--- a/environment/deployments/ppdb/env/dev-services.tfvars
+++ b/environment/deployments/ppdb/env/dev-services.tfvars
@@ -23,4 +23,4 @@ create_gh_ci_sa = true
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 4
+# Serial: 5

--- a/environment/deployments/ppdb/services/bigquery.tf
+++ b/environment/deployments/ppdb/services/bigquery.tf
@@ -39,6 +39,13 @@ resource "google_bigquery_dataset_iam_member" "tap_sa_access_ppdb_public" {
   role          = "roles/bigquery.dataViewer"
 }
 
+resource "google_bigquery_dataset_iam_member" "tap_sa_access_ppdb_internal" {
+  dataset_id    = google_bigquery_dataset.ppdb_internal.dataset_id 
+  member        = local.bigquery_tap_sa_entry.member
+  project       = local.project_id
+  role          = "roles/bigquery.dataViewer"
+}
+
 # PPDB Staging
 resource "google_bigquery_dataset" "ppdb_staging" {
   dataset_id                 = "ppdb_staging"

--- a/environment/deployments/ppdb/services/bigquery.tf
+++ b/environment/deployments/ppdb/services/bigquery.tf
@@ -26,6 +26,12 @@ resource "google_project_iam_member" "tap_sa_job_user" {
   project = local.project_id
 }
 
+resource "google_project_iam_member" "tap_sa_read_session" {
+  role    = "roles/bigquery.readSessionUser"
+  member = local.bigquery_tap_sa_entry.member
+  project = local.project_id
+}
+
 resource "google_bigquery_dataset_iam_member" "tap_sa_access_ppdb_public" {
   dataset_id    = google_bigquery_dataset.ppdb_public.dataset_id 
   member        = local.bigquery_tap_sa_entry.member

--- a/environment/deployments/ppdb/services/bigquery.tf
+++ b/environment/deployments/ppdb/services/bigquery.tf
@@ -20,6 +20,12 @@ resource "google_bigquery_dataset" "ppdb_public" {
   delete_contents_on_destroy = false
 }
 
+resource "google_project_iam_member" "tap_sa_job_user" {
+  role    = "roles/bigquery.jobUser"
+  member = local.bigquery_tap_sa_entry.member
+  project = local.project_id
+}
+
 resource "google_bigquery_dataset_iam_member" "tap_sa_access_ppdb_public" {
   dataset_id    = google_bigquery_dataset.ppdb_public.dataset_id 
   member        = local.bigquery_tap_sa_entry.member

--- a/environment/deployments/ppdb/services/bigquery.tf
+++ b/environment/deployments/ppdb/services/bigquery.tf
@@ -20,6 +20,13 @@ resource "google_bigquery_dataset" "ppdb_public" {
   delete_contents_on_destroy = false
 }
 
+resource "google_bigquery_dataset_iam_member" "tap_sa_access_ppdb_public" {
+  dataset_id    = google_bigquery_dataset.ppdb_public.dataset_id 
+  member        = local.bigquery_tap_sa_entry.member
+  project       = local.project_id
+  role          = "roles/bigquery.dataViewer"
+}
+
 # PPDB Staging
 resource "google_bigquery_dataset" "ppdb_staging" {
   dataset_id                 = "ppdb_staging"
@@ -41,3 +48,4 @@ resource "google_bigquery_dataset" "ppdb_backup" {
   max_time_travel_hours      = var.bigquery_max_time_travel_hours
   delete_contents_on_destroy = false
 }
+

--- a/environment/deployments/ppdb/services/locals.tf
+++ b/environment/deployments/ppdb/services/locals.tf
@@ -16,4 +16,6 @@ locals {
       "https://www.googleapis.com/compute/v1/",
       ""
     )
+
+    bigquery_tap_sa_entry = data.terraform_remote_state.science_platform_cloudsql.outputs.service_accounts_map["bigquery-kafka"]
 }

--- a/environment/deployments/ppdb/services/main.tf
+++ b/environment/deployments/ppdb/services/main.tf
@@ -15,3 +15,12 @@ data "terraform_remote_state" "ppdb_cloud_sql" {
     bucket = var.state_bucket
   }
 }
+
+data "terraform_remote_state" "science_platform_cloudsql" {
+  backend = "gcs"
+
+  config = {
+    prefix = "science-platform/${var.environment}/cloudsql"
+    bucket = var.state_bucket
+  }
+}


### PR DESCRIPTION
This pull request introduces configuration changes to grant the BigQuery TAP Science Platform service account access to the `ppdb_public` BigQuery dataset and to enable retrieval of this service account from remote state. The main changes involve adding IAM permissions, updating local variables, and referencing remote state outputs.

**BigQuery IAM permissions:**

* Added a `google_bigquery_dataset_iam_member` resource to grant the `bigquery-kafka` service account `roles/bigquery.dataViewer` access to the `ppdb_public` dataset.

**Remote state and locals updates:**

* Added a `terraform_remote_state` data source for `science_platform_cloudsql` to retrieve outputs from the science platform's CloudSQL state.
* Updated `locals.tf` to include `bigquery_tap_sa_entry`, referencing the `bigquery-kafka` service account from the remote state outputs.
