### PR TITLE
PPDB - Remove admin cloudsql.instanceUser role

### DIFF
--- a/environment/foundation/1-org-b/1-org-b.tfvars
+++ b/environment/foundation/1-org-b/1-org-b.tfvars
@@ -143,5 +143,4 @@ gcp_ppdb_administrators_iam_permissions = [
   "roles/monitoring.editor",
   "roles/run.viewer",
   "roles/storage.objectViewer",
-  "roles/cloudsql.instanceUser",
 ]


### PR DESCRIPTION
We shouldn't explicitly need to specify it.