### PR TITLE
PPDB - Make the cloudrun function depend on IAM role assignment

### DIFF
--- a/environment/deployments/ppdb/env/int-services.tfvars
+++ b/environment/deployments/ppdb/env/int-services.tfvars
@@ -23,4 +23,4 @@ create_gh_ci_sa = true
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 5
+# Serial: 6

--- a/environment/deployments/ppdb/services/SQL/iam-sa-permissions.sql
+++ b/environment/deployments/ppdb/services/SQL/iam-sa-permissions.sql
@@ -1,17 +1,17 @@
 -- USDF Replication
-GRANT USAGE ON SCHEMA ppdb_chunk_tracking TO "usdf-replication@ppdb-dev-5c07.iam";
-GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA ppdb_chunk_tracking TO "usdf-replication@ppdb-dev-5c07.iam";
+GRANT USAGE ON SCHEMA ppdb_chunk_tracking TO "usdf-replication@ppdb-int-6c62.iam";
+GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA ppdb_chunk_tracking TO "usdf-replication@ppdb-int-6c62.iam";
 ALTER DEFAULT PRIVILEGES IN SCHEMA ppdb_chunk_tracking
-GRANT SELECT, INSERT ON TABLES TO "usdf-replication@ppdb-dev-5c07.iam";
+GRANT SELECT, INSERT ON TABLES TO "usdf-replication@ppdb-int-6c62.iam";
 
 -- Cloud Run Promote Chunks
-GRANT USAGE ON SCHEMA ppdb_chunk_tracking TO "cloudrun-promote-chunks@ppdb-dev-5c07.iam";
-GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA ppdb_chunk_tracking TO "cloudrun-promote-chunks@ppdb-dev-5c07.iam";
+GRANT USAGE ON SCHEMA ppdb_chunk_tracking TO "cloudrun-promote-chunks@ppdb-int-6c62.iam";
+GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA ppdb_chunk_tracking TO "cloudrun-promote-chunks@ppdb-int-6c62.iam";
 ALTER DEFAULT PRIVILEGES IN SCHEMA ppdb_chunk_tracking
-GRANT SELECT, INSERT ON TABLES TO "cloudrun-promote-chunks@ppdb-dev-5c07.iam";
+GRANT SELECT, INSERT ON TABLES TO "cloudrun-promote-chunks@ppdb-int-6c62.iam";
 
 -- Cloud Run Track Chunks
-GRANT USAGE ON SCHEMA ppdb_chunk_tracking TO "cloudrun-track-chunks@ppdb-dev-5c07.iam";
-GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA ppdb_chunk_tracking TO "cloudrun-track-chunks@ppdb-dev-5c07.iam";
+GRANT USAGE ON SCHEMA ppdb_chunk_tracking TO "cloudrun-track-chunks@ppdb-int-6c62.iam";
+GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA ppdb_chunk_tracking TO "cloudrun-track-chunks@ppdb-int-6c62.iam";
 ALTER DEFAULT PRIVILEGES IN SCHEMA ppdb_chunk_tracking
-GRANT SELECT, INSERT ON TABLES TO "cloudrun-track-chunks@ppdb-dev-5c07.iam";
+GRANT SELECT, INSERT ON TABLES TO "cloudrun-track-chunks@ppdb-int-6c62.iam";

--- a/environment/deployments/ppdb/services/promote-chunks.tf
+++ b/environment/deployments/ppdb/services/promote-chunks.tf
@@ -14,8 +14,8 @@ resource "google_storage_bucket_iam_member" "cloudrun_promote_chunks_ingest_obje
 resource "google_bigquery_dataset_access" "cloudrun_promote_chunks_staging_dataset_editor" {
   dataset_id = google_bigquery_dataset.ppdb_staging.dataset_id
   role       = "roles/bigquery.dataEditor"
-  iam_member  = "serviceAccount:${google_service_account.cloudrun_promote_chunks.email}"
-  project = local.project_id
+  iam_member = "serviceAccount:${google_service_account.cloudrun_promote_chunks.email}"
+  project    = local.project_id
 }
 
 resource "google_project_iam_member" "cloudrun_promote_chunks_bq_job_user" {
@@ -56,6 +56,17 @@ resource "google_cloudfunctions2_function" "promote_chunks" {
   project     = local.project_id
   location    = var.region
   description = "Promotes Chunks"
+
+  depends_on = [
+    google_project_iam_member.cloudrun_deploy_functions_developer,
+    google_project_iam_member.cloudrun_deploy_run_developer,
+    google_project_iam_member.cloudrun_deploy_service_account_user,
+    google_project_iam_member.cloudrun_deploy_builds_editor,
+    google_project_iam_member.cloudrun_deploy_artifact_registry_writer,
+    google_project_iam_member.cloudrun_deploy_storage_admin,
+    google_project_iam_member.cloudrun_deploy_storage_object_admin,
+    google_project_iam_member.cloudrun_deploy_service_account_token_creator,
+  ]
 
   build_config {
     runtime         = var.promote_chunks_runtime

--- a/environment/deployments/ppdb/services/track-chunk.tf
+++ b/environment/deployments/ppdb/services/track-chunk.tf
@@ -74,7 +74,7 @@ resource "google_eventarc_trigger" "pubsub_trigger_track_chunk" {
   destination {
     cloud_run_service {
       service = google_cloudfunctions2_function.track_chunk.name
-      region = var.region
+      region  = var.region
     }
   }
 }
@@ -85,6 +85,17 @@ resource "google_cloudfunctions2_function" "track_chunk" {
   project     = local.project_id
   location    = var.region
   description = "Tracks processing chunks"
+
+  depends_on = [
+    google_project_iam_member.cloudrun_deploy_functions_developer,
+    google_project_iam_member.cloudrun_deploy_run_developer,
+    google_project_iam_member.cloudrun_deploy_service_account_user,
+    google_project_iam_member.cloudrun_deploy_builds_editor,
+    google_project_iam_member.cloudrun_deploy_artifact_registry_writer,
+    google_project_iam_member.cloudrun_deploy_storage_admin,
+    google_project_iam_member.cloudrun_deploy_storage_object_admin,
+    google_project_iam_member.cloudrun_deploy_service_account_token_creator,
+  ]
 
   build_config {
     runtime         = var.track_chunk_runtime

--- a/environment/deployments/ppdb/services/trigger-stage-chunk.tf
+++ b/environment/deployments/ppdb/services/trigger-stage-chunk.tf
@@ -12,9 +12,9 @@ resource "google_project_iam_member" "cloudrun_trigger_stage_chunk_dataflow" {
 }
 
 resource "google_pubsub_topic_iam_member" "cloudrun_trigger_stage_chunk_sa_stage_chunk_topic" {
-  topic  = google_pubsub_topic.stage_chunk_topic.id
-  role   = "roles/pubsub.subscriber"
-  member = "serviceAccount:${google_service_account.cloudrun_trigger_stage_chunk.email}"
+  topic   = google_pubsub_topic.stage_chunk_topic.id
+  role    = "roles/pubsub.subscriber"
+  member  = "serviceAccount:${google_service_account.cloudrun_trigger_stage_chunk.email}"
   project = local.project_id
 }
 
@@ -26,14 +26,14 @@ resource "google_storage_bucket_iam_member" "cloudrun_trigger_stage_chunks_dataf
 
 resource "google_project_iam_member" "cloudrun_trigger_stage_chunks_storage_admin" {
   role    = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.cloudrun_trigger_stage_chunk.email}"
+  member  = "serviceAccount:${google_service_account.cloudrun_trigger_stage_chunk.email}"
   project = local.project_id
 }
 
 resource "google_service_account_iam_member" "cloudrun_trigger_stage_chunks_dataflow_sa_impersonation" {
   service_account_id = google_service_account.dataflow_stage_chunk.name
   role               = "roles/iam.serviceAccountUser"
-  member = "serviceAccount:${google_service_account.cloudrun_trigger_stage_chunk.email}"
+  member             = "serviceAccount:${google_service_account.cloudrun_trigger_stage_chunk.email}"
 }
 
 
@@ -91,6 +91,17 @@ resource "google_cloudfunctions2_function" "trigger_stage_chunk" {
   project     = local.project_id
   location    = var.region
   description = "Triggers Stage Chunks"
+
+  depends_on = [
+    google_project_iam_member.cloudrun_deploy_functions_developer,
+    google_project_iam_member.cloudrun_deploy_run_developer,
+    google_project_iam_member.cloudrun_deploy_service_account_user,
+    google_project_iam_member.cloudrun_deploy_builds_editor,
+    google_project_iam_member.cloudrun_deploy_artifact_registry_writer,
+    google_project_iam_member.cloudrun_deploy_storage_admin,
+    google_project_iam_member.cloudrun_deploy_storage_object_admin,
+    google_project_iam_member.cloudrun_deploy_service_account_token_creator,
+  ]
 
   build_config {
     runtime         = var.trigger_stage_chunk_runtime

--- a/environment/deployments/ppdb/services/usdf-replication.tf
+++ b/environment/deployments/ppdb/services/usdf-replication.tf
@@ -7,9 +7,9 @@ resource "google_service_account" "usdf_replication" {
 }
 
 resource "google_pubsub_topic_iam_member" "usdf_replication_stage_chunk_topic" {
-  topic  = google_pubsub_topic.stage_chunk_topic.id
-  role   = "roles/pubsub.publisher"
-  member = "serviceAccount:${google_service_account.usdf_replication.email}"
+  topic   = google_pubsub_topic.stage_chunk_topic.id
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.usdf_replication.email}"
   project = local.project_id
 }
 
@@ -36,3 +36,4 @@ resource "google_storage_bucket_iam_member" "usdf_replication_gcs_config_viewer"
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.usdf_replication.email}"
 }
+


### PR DESCRIPTION
Otherwise, there's a race condition where Terraform tries to provision the cloudrun functions before all necessary roles have been assigned to the service accounts, and then provisioning fails.