### PR TITLE
DM-55784: Refactor Promote Chunks to Cloud Run Job

### DIFF
--- a/environment/deployments/ppdb/env/dev-services.tfvars
+++ b/environment/deployments/ppdb/env/dev-services.tfvars
@@ -5,11 +5,12 @@ state_bucket     = "lsst-terraform-state"
 
 # Promote Chunks Cloud Run
 promote_chunks_cloud_run_ppdb_config_uri = "gs://ppdb-dev-config/ppdb_dev.yaml"
-promote_chunks_runtime = "python313"
+promote_chunks_db_name = "ppdb-chunk-tracking"
 
 # Track Chunk Cloud Run
 track_chunk_cloud_run_ppdb_config_uri = "gs://ppdb-dev-config/ppdb_dev.yaml"
 track_chunk_runtime = "python313"
+track_chunk_db_name = "ppdb-chunk-tracking"
 
 # Trigger Stage Chunks Cloud Run
 trigger_stage_chunk_cloud_run_dataflow_template_path = "gs://ppdb-dev-dataflow/templates/stage_chunk_flex_template.json"

--- a/environment/deployments/ppdb/env/dev.tfvars
+++ b/environment/deployments/ppdb/env/dev.tfvars
@@ -28,32 +28,6 @@ secondary_ranges = {
   ]
 }
 
-# Enable Google Artifact Registry, Service Networking, Container Filesystem,
-# and Cloud SQL Admin (required for the Cloud SQL Auth Proxy) in addition to
-# our standard APIs.
-activate_apis = [
-  "artifactregistry.googleapis.com",
-  "bigquery.googleapis.com",
-  "billingbudgets.googleapis.com",
-  "cloudbuild.googleapis.com",
-  "cloudfunctions.googleapis.com",
-  "cloudresourcemanager.googleapis.com",
-  "cloudscheduler.googleapis.com",
-  "compute.googleapis.com",
-  "dataflow.googleapis.com",
-  "eventarc.googleapis.com",
-  "iam.googleapis.com",
-  "logging.googleapis.com",
-  "monitoring.googleapis.com",
-  "pubsub.googleapis.com",
-  "run.googleapis.com",
-  "secretmanager.googleapis.com",
-  "servicenetworking.googleapis.com",
-  "serviceusage.googleapis.com",
-  "sqladmin.googleapis.com",
-  "storage.googleapis.com"
-]
-
 # If you didn't make any other changes to this file, increase this number to
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that

--- a/environment/deployments/ppdb/env/int-services.tfvars
+++ b/environment/deployments/ppdb/env/int-services.tfvars
@@ -23,4 +23,4 @@ create_gh_ci_sa = true
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 8
+# Serial: 9

--- a/environment/deployments/ppdb/env/int-services.tfvars
+++ b/environment/deployments/ppdb/env/int-services.tfvars
@@ -5,7 +5,6 @@ state_bucket     = "lsst-terraform-state"
 
 # Promote Chunks Cloud Run
 promote_chunks_cloud_run_ppdb_config_uri = "gs://ppdb-int-config/ppdb_int.yaml"
-promote_chunks_runtime = "python313"
 
 # Track Chunk Cloud Run
 track_chunk_cloud_run_ppdb_config_uri = "gs://ppdb-int-config/ppdb_int.yaml"

--- a/environment/deployments/ppdb/env/int.tfvars
+++ b/environment/deployments/ppdb/env/int.tfvars
@@ -28,32 +28,6 @@ secondary_ranges = {
   ]
 }
 
-# Enable Google Artifact Registry, Service Networking, Container Filesystem,
-# and Cloud SQL Admin (required for the Cloud SQL Auth Proxy) in addition to
-# our standard APIs.
-activate_apis = [
-  "artifactregistry.googleapis.com",
-  "bigquery.googleapis.com",
-  "billingbudgets.googleapis.com",
-  "cloudbuild.googleapis.com",
-  "cloudfunctions.googleapis.com",
-  "cloudresourcemanager.googleapis.com",
-  "cloudscheduler.googleapis.com",
-  "compute.googleapis.com",
-  "dataflow.googleapis.com",
-  "eventarc.googleapis.com",
-  "iam.googleapis.com",
-  "logging.googleapis.com",
-  "monitoring.googleapis.com",
-  "pubsub.googleapis.com",
-  "run.googleapis.com",
-  "secretmanager.googleapis.com",
-  "servicenetworking.googleapis.com",
-  "serviceusage.googleapis.com",
-  "sqladmin.googleapis.com",
-  "storage.googleapis.com"
-]
-
 # If you didn't make any other changes to this file, increase this number to
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that

--- a/environment/deployments/ppdb/services/backend.tf
+++ b/environment/deployments/ppdb/services/backend.tf
@@ -9,3 +9,11 @@ terraform {
     google-beta = ">= 6.26"
   }
 }
+
+provider "google" {
+  project = local.project_id
+}
+
+provider "google-beta" {
+  project = local.project_id
+}

--- a/environment/deployments/ppdb/services/promote-chunks.tf
+++ b/environment/deployments/ppdb/services/promote-chunks.tf
@@ -50,12 +50,103 @@ resource "google_sql_user" "cloudrun_promote_chunks_iam_sql_user" {
   project  = local.project_id
 }
 
-# Cloud Run Functions Gen2 Definition
-resource "google_cloudfunctions2_function" "promote_chunks" {
+# Workflow Service Account
+resource "google_service_account" "promote_chunks_workflow" {
+  account_id   = "promote-chunks-workflow-runner"
+  display_name = "Service Account for Promote Chunks Cloud Workflow"
+  project       = local.project_id
+}
+
+resource "google_project_iam_member" "promote_chunks_workflow_cloudrun_developer" {
+  project = local.project_id
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.promote_chunks_workflow.email}"
+}
+
+resource "google_project_iam_member" "promote_chunks_workflow_token_creator" {
+  project = local.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${google_service_account.promote_chunks_workflow.email}"
+}
+
+
+# Workflow Definition
+resource "google_workflows_workflow" "promote_chunks_run_job_workflow" {
+  name            = "trigger-promote-chunks-cloudrun-job-workflow"
+  region          = var.region
+  description     = "Workflow that executes the promote chunks Cloud Run Job"
+  service_account = google_service_account.promote_chunks_workflow.id
+  project         = local.project_id
+
+  source_contents = <<EOF
+main:
+  steps:
+    - init:
+        assign:
+          - project_id: $${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+          - job_name: "${google_cloud_run_v2_job.promote_chunks.name}"
+          - location: "${google_cloud_run_v2_job.promote_chunks.location}"
+    - run_cloud_run_job:
+        call: googleapis.run.v2.projects.locations.jobs.run
+        args:
+          name: $${"projects/" + project_id + "/locations/" + location + "/jobs/" + job_name}
+        result: job_execution    
+    - finish:
+        return: $${job_execution}
+EOF
+}
+
+# Cloud Scheduler
+
+resource "google_service_account" "promote_chunks_scheduler" {
+  account_id   = "promote-chunks-cloud-scheduler"
+  display_name = "Promote Chunks Cloud Scheduler Workflow Invoker SA"
+  project      = local.project_id
+}
+
+resource "google_project_iam_member" "promote_chunks_scheduler_workflow_invoker" {
+  project = local.project_id
+  role    = "roles/workflows.invoker"
+  member  = "serviceAccount:${google_service_account.promote_chunks_scheduler.email}"
+}
+
+resource "google_cloud_scheduler_job" "promote_chunks_workflow_scheduler" {
+  name             = "schedule-promote-chunks-workflow-job"
+  description      = "Triggers the Promote Chunks Cloud Workflow every day"
+  schedule         = var.promote_chunks_schedule
+  time_zone        = var.promote_chunks_scheduler_timezone
+  region           = var.region
+  attempt_deadline = var.promote_chunks_scheduler_attempt_deadline
+  project          = local.project_id
+
+  http_target {
+    http_method = "POST"
+    # End point to trigger a workflow execution
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.promote_chunks_run_job_workflow.id}/executions"
+
+    # Empty arguments body needed to for POST to run the workflow.
+    body = base64encode(
+                        <<-EOF
+                            {"argument":"{}","callLogLevel":"LOG_ALL_CALLS"} 
+                        EOF
+                       )
+
+    headers = {
+      "content-type" = "application/octet-stream"
+    }
+
+    oauth_token {
+      service_account_email = google_service_account.promote_chunks_scheduler.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+}
+
+# Cloud Run Job Definition
+resource "google_cloud_run_v2_job" "promote_chunks" {
   name        = "promote-chunks"
-  project     = local.project_id
   location    = var.region
-  description = "Promotes Chunks"
+  project     = local.project_id
 
   depends_on = [
     google_project_iam_member.cloudrun_deploy_functions_developer,
@@ -68,65 +159,68 @@ resource "google_cloudfunctions2_function" "promote_chunks" {
     google_project_iam_member.cloudrun_deploy_service_account_token_creator,
   ]
 
-  build_config {
-    runtime         = var.promote_chunks_runtime
-    entry_point     = "promote_chunks"
-    service_account = google_service_account.cloudrun_build.id
+  template{
+    template{
+      service_account       = google_service_account.cloudrun_promote_chunks.email
+      execution_environment = var.promote_chunks_cloud_run_execution_environment
+      timeout               = var.promote_chunks_timeout
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/hello-job:latest"
 
-    # Placeholder source code bucket/object for initial creation
-    source {
-      storage_source {
-        bucket = google_storage_bucket_object.placeholder_zip_promote_chunks.bucket
-        object = google_storage_bucket_object.placeholder_zip_promote_chunks.name
+        env {
+          name  = "PPDB_CONFIG_URI"
+          value = var.promote_chunks_cloud_run_ppdb_config_uri
+        }
+        env {
+          name  = "PPDB_USE_SECRET_MANAGER"
+          value = var.promote_chunks_cloud_run_ppdb_use_secret_manager
+        }
+        env {
+          name  = "CLOUDSQL_ENABLED"
+          value = "true"
+        }
+        env {
+          name  = "CLOUDSQL_IP_TYPE"
+          value = "private"
+        }
+        env {
+          name  = "CLOUDSQL_INSTANCE_CONNECTION_NAME"
+          value = "${local.project_id}:${var.region}:${local.sql_instance_name}"
+        }
+        env {
+          name  = "CLOUDSQL_USER"
+          value = "${google_service_account.cloudrun_promote_chunks.account_id}@${local.project_id}.iam"
+        }
+        env {
+          name  = "CLOUDSQL_DB_NAME"
+          value = var.promote_chunks_db_name
+        }
+        resources {
+
+          limits = {
+            cpu    = var.promote_chunks_cloud_run_cpu_limit
+            memory = var.promote_chunks_cloud_run_memory_limit
+          }
+        }
+      }
+      vpc_access {
+        egress = "PRIVATE_RANGES_ONLY"
+        
+        network_interfaces {
+          network    = local.network
+          subnetwork = local.subnet
+        }
       }
     }
   }
 
-  service_config {
-    service_account_email            = google_service_account.cloudrun_promote_chunks.email
-    min_instance_count               = var.promote_chunks_cloud_run_min_instance_count
-    max_instance_count               = var.promote_chunks_cloud_run_max_instance_count
-    max_instance_request_concurrency = var.promote_chunks_cloud_run_concurrency
-
-    direct_vpc_network_interface {
-      network    = local.network
-      subnetwork = local.subnet
-    }
-    direct_vpc_egress = "VPC_EGRESS_PRIVATE_RANGES_ONLY"
-
-    environment_variables = {
-      PPDB_CONFIG_URI                   = var.promote_chunks_cloud_run_ppdb_config_uri
-      PPDB_USE_SECRET_MANAGER           = var.promote_chunks_cloud_run_ppdb_use_secret_manager
-      CLOUDSQL_ENABLED                  = "true"
-      CLOUDSQL_IP_TYPE                  = "private"
-      CLOUDSQL_INSTANCE_CONNECTION_NAME = "${local.project_id}:${var.region}:ppdb-${var.environment}"
-      CLOUDSQL_USER                     = "${google_service_account.cloudrun_promote_chunks.account_id}@${local.project_id}.iam"
-      CLOUDSQL_DB_NAME                  = "ppdb"
-    }
-  }
-
-  # Instructs Terraform to ignore modifications to the source code artifact made by CI
+  # Lifecycle policy to ignore changes to the container image.  The deploy action in the ppdb-cloud-functions repo updates the image.
   lifecycle {
     ignore_changes = [
-      build_config[0].source,
+      template[0].template[0].containers[0].image,
+      template[0].labels,
+      client,
+      client_version
     ]
   }
-}
-
-# Dummy zip file to build function
-data "archive_file" "dummy_source_promote_chunks" {
-  type        = "zip"
-  output_path = "${path.module}/dummy_source_promote_chunks.zip"
-
-  source {
-    content  = "def promote_chunks(event, context=None):\n    return 'OK'"
-    filename = "main.py"
-  }
-}
-
-# Upload the dummy zip to Cloud Storage
-resource "google_storage_bucket_object" "placeholder_zip_promote_chunks" {
-  name   = "source/placeholder-promote-chunks.zip"
-  bucket = google_storage_bucket.config.id
-  source = data.archive_file.dummy_source_promote_chunks.output_path
 }

--- a/environment/deployments/ppdb/services/track-chunk.tf
+++ b/environment/deployments/ppdb/services/track-chunk.tf
@@ -130,7 +130,7 @@ resource "google_cloudfunctions2_function" "track_chunk" {
       CLOUDSQL_IP_TYPE                  = "private"
       CLOUDSQL_INSTANCE_CONNECTION_NAME = "${local.project_id}:${var.region}:ppdb-${var.environment}"
       CLOUDSQL_USER                     = "${google_service_account.cloudrun_track_chunks.account_id}@${local.project_id}.iam"
-      CLOUDSQL_DB_NAME                  = "ppdb"
+      CLOUDSQL_DB_NAME                  = var.track_chunk_db_name
     }
   }
 

--- a/environment/deployments/ppdb/services/variables.tf
+++ b/environment/deployments/ppdb/services/variables.tf
@@ -123,16 +123,84 @@ variable "promote_chunks_cloud_run_log_execution_id" {
 
 }
 
-variable "promote_chunks_runtime" {
-  description = "Runtime for Cloud Run Functions"
-  type        = string
-}
-
 variable "promote_chunks_cloud_run_retry_policy" {
   description = "Cloud Run retry policy"
   default     = "RETRY_POLICY_DO_NOT_RETRY"
   type        = string
 }
+
+variable "promote_chunks_schedule" {
+  description = "Cron time for Cloud Scheduler to schedule Promote Chunks to run"
+  type        = string
+  default     = "0 12 * * *"
+}
+
+variable "promote_chunks_scheduler_timezone" {
+  description = "Timezone for Promote Chunks scheduler"
+  type        = string
+  default     = "America/Santiago"
+}
+
+variable "promote_chunks_scheduler_attempt_deadline" {
+  description = "The deadline for job attempts"
+  type        = string
+  default     = "180s"
+}
+
+variable "promote_chunks_scheduler_min_backoff_duration" {
+  description = "The maximum amount of time to wait before retrying a job after it fails."
+  type        = string
+  default     = "1s"
+}
+
+variable "promote_chunks_scheduler_max_retry_duration" {
+  description = "The time limit for retrying a failed job, measured from time when an execution was first attempted. If specified with retryCount, the job will be retried until both limits are reached."
+  type        = string
+  default     = "10s"
+}
+
+variable "promote_chunks_scheduler_max_doublings" {
+  description = "The time between retries will double maxDoublings times."
+  type        = number
+  default     = 2
+}
+
+variable "promote_chunks_scheduler_retry_count" {
+  description = "The number of attempts that the system will make to run a job using the exponential backoff procedure described by maxDoublings"
+  type        = number
+  default     = 3
+}
+
+variable "promote_chunks_cloud_run_cpu_limit" {
+  description = "CPU limit"
+  default     = 4
+  type        = number
+}
+
+variable "promote_chunks_cloud_run_memory_limit" {
+  description = "Memory limit"
+  default     = "16Gi"
+  type        = string
+}
+
+variable "promote_chunks_db_name" {
+  description = "CloudSQL Database name"
+  default     = "ppdb"
+  type        = string
+}
+
+variable "promote_chunks_cloud_run_execution_environment" {
+  description = "Cloud Run execution environment"
+  default     = "EXECUTION_ENVIRONMENT_GEN2"
+  type        = string
+}
+
+variable "promote_chunks_timeout" {
+  description = "Promote Chunks timeout"
+  default     = "7200s"
+  type        = string
+}
+
 
 # Track Chunk Cloud Run
 
@@ -173,6 +241,12 @@ variable "track_chunk_runtime" {
 variable "track_chunk_cloud_run_retry_policy" {
   description = "Cloud Run retry policy"
   default     = "RETRY_POLICY_DO_NOT_RETRY"
+  type        = string
+}
+
+variable "track_chunk_db_name" {
+  description = "CloudSQL Database name"
+  default     = "ppdb"
   type        = string
 }
 

--- a/environment/deployments/ppdb/variables.tf
+++ b/environment/deployments/ppdb/variables.tf
@@ -26,18 +26,27 @@ variable "activate_apis" {
   description = "The api to activate for the GCP project"
   type        = list(string)
   default = [
+    "artifactregistry.googleapis.com",
     "bigquery.googleapis.com",
     "billingbudgets.googleapis.com",
+    "cloudbuild.googleapis.com",
     "cloudfunctions.googleapis.com",
-    "dataproc.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "compute.googleapis.com",
+    "dataflow.googleapis.com",
     "eventarc.googleapis.com",
+    "iam.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",
     "pubsub.googleapis.com",
     "run.googleapis.com",
     "secretmanager.googleapis.com",
     "servicenetworking.googleapis.com",
-    "storage.googleapis.com"
+    "serviceusage.googleapis.com",
+    "sqladmin.googleapis.com",
+    "storage.googleapis.com",
+    "workflows.googleapis.com"
   ]
 }
 


### PR DESCRIPTION
This pull request introduces significant changes to the infrastructure for the "Promote Chunks" and "Track Chunk" services, focusing on migrating the Promote Chunks service from Cloud Functions to Cloud Run Jobs orchestrated by Workflows and scheduled via Cloud Scheduler. It also improves configuration flexibility and resource management by introducing new variables and updating environment files.

**Promote Chunks Service Migration and Orchestration:**

* Migrated the `promote-chunks` service from Cloud Functions to a Cloud Run Job, enabling more robust execution and better resource control. Added a Workflow to trigger the Cloud Run Job and a Cloud Scheduler job to automate its execution. New service accounts and IAM roles were created to support these changes.

**Configuration and Variable Enhancements:**

* Introduced new variables for resource limits (CPU, memory), scheduling (cron, timezone, retry/backoff policies), and database names for both Promote Chunks and Track Chunk services, improving flexibility and maintainability.
* Updated environment variable usage in Cloud Run Job definitions to use the new variables for database names and configuration, ensuring environment-specific customization. 

**API Activation and Environment File Updates:**

* Centralized the list of required Google Cloud APIs into the main variables file, removing redundant or outdated lists from environment-specific files.

**Other Minor Updates:**

* Incremented the serial number in the `int-services.tfvars` file to force Terraform to update the environment.