### PR TITLE
USDFSM-114: Add Folder for USDF Backups

### DIFF
--- a/environment/foundation/1-org/1-org.tfvars
+++ b/environment/foundation/1-org/1-org.tfvars
@@ -1,7 +1,7 @@
 // Folder Variables
 
 parent_folder                 = ""
-folder_names                  = ["SQuaRE", "Science Platform", "Processing", "Scratch", "EPO", "Alert Production", "PPDB"]
+folder_names                  = ["SQuaRE", "Science Platform", "Processing", "Scratch", "EPO", "Alert Production", "PPDB", "USDF Backups"]
 seed_folder_name              = "370233560583"
 
 // Organization Viewer IAM Roles


### PR DESCRIPTION
USDF backups from APDB will start to be synced to GCP for an offsite location.  This create a folder for the projects.  Ignore the budget alert changes.  It is a known issue that it shows up as a change each time.