### PR TITLE
ppdb - Destroy int GitHub CI Google Cloud IAM user

### DIFF
--- a/environment/deployments/ppdb/env/int-services.tfvars
+++ b/environment/deployments/ppdb/env/int-services.tfvars
@@ -15,9 +15,6 @@ trigger_stage_chunk_cloud_run_dataflow_template_path = "gs://ppdb-int-dataflow/t
 trigger_stage_chunk_cloud_run_temp_location = "gs://ppdb-int-dataflow/temp"
 trigger_stage_chunk_runtime = "python313"
 
-# GitHub CI
-create_gh_ci_sa = true
-
 # If you didn't make any other changes to this file, increase this number to
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that


### PR DESCRIPTION
The GitHub CI Google Cloud IAM user is used in the `https://github.com/lsst/dax_ppdb` CI workflow, but that workflow will always use the `ppdb-dev` user; we don't need more than one.