### PR TITLE
ppdb - Delete duplicate track-chunk trigger

### DIFF
--- a/environment/deployments/ppdb/env/dev-services.tfvars
+++ b/environment/deployments/ppdb/env/dev-services.tfvars
@@ -22,4 +22,4 @@ create_gh_ci_sa = true
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 5
+# Serial: 6

--- a/environment/deployments/ppdb/env/int-services.tfvars
+++ b/environment/deployments/ppdb/env/int-services.tfvars
@@ -19,4 +19,4 @@ trigger_stage_chunk_runtime = "python313"
 # force Terraform to update this environment. You may need to do this if you
 # changed .tf files in this environment, or if you changed any modules that
 # this environment uses, but you didn't change any variables in this file.
-# Serial: 9
+# Serial: 10

--- a/environment/deployments/ppdb/services/track-chunk.tf
+++ b/environment/deployments/ppdb/services/track-chunk.tf
@@ -134,13 +134,6 @@ resource "google_cloudfunctions2_function" "track_chunk" {
     }
   }
 
-  event_trigger {
-    trigger_region = var.region
-    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
-    pubsub_topic   = "projects/${local.project_id}/topics/track-chunk-topic"
-    retry_policy   = var.track_chunk_cloud_run_retry_policy
-  }
-
   # Instructs Terraform to ignore modifications to the source code artifact made by CI
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
There are two Eventarc triggers for the track-chunk CloudRun function. One of them is fine and triggers the function, one of them causes a bunch of 403s.  In the terraform config, we're explicitly creating an eventarc trigger as a separate resource for that function, and we're also configuring the function to make its own trigger. We only want our separate one (that’s the one that works).